### PR TITLE
Include _modelType in dataSet handling

### DIFF
--- a/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
@@ -55,7 +55,7 @@ export class SelectDataDialogComponent implements OnInit {
     this.allDatasets = this.datasetService.datasetListDatasets({ myData: false });
     this.datasets = this.myDatasets = this.datasetService.datasetListDatasets({ myData: true });
     this.datasets.pipe(enterZone(this.zone)).subscribe(datasets => {
-      this.data.tale.dataSet.forEach((ds: { itemId: string, mountPath: string }) => {
+      this.data.tale.dataSet.forEach((ds: { itemId: string, mountPath: string, _modelType: string }) => {
         // Lookup the Dataset by id and push it to our selection
         const dataset = datasets.find((data: Dataset) => data._id === ds.itemId);
         if (dataset) {

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -598,8 +598,7 @@ export class TaleFilesComponent implements OnInit, OnChanges {
       const tale = this.tale;
       tale.dataSet = [];
       datasets.forEach(ds => {
-        // TODO: leading slash?
-        tale.dataSet.push({ itemId: ds._id, mountPath: ds.name })
+        tale.dataSet.push({ itemId: ds._id, mountPath: ds.name, _modelType: ds._modelType })
       });
 
       this.taleService.taleUpdateTale({ id: tale._id, tale }).subscribe(response => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

[x] Bugfix

## What is the current behavior?
Updating `dataSet` fails due to the missing keyword.

## What is the new behavior?
`_modelType` is included in `dataSet` during `PUT /tale/:id`

##  Does this PR introduce a breaking change?
No