### PR TITLE
Expand Run view paddleboard dropdown, add icons

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -34,17 +34,29 @@
                                     <a routerLink="/" routerLinkActive="active" class="ui button" style="margin-right: 10px">
                                       Close
                                     </a>
+
+
                                     <div class="ui floating dropdown theme" tabindex="0">
                                         <mat-icon fontSet="fa" fontIcon="fa-ellipsis-v"></mat-icon>
 
                                         <div class="menu transition hidden" tabindex="-1">
-                                            <div class="item" (click)="rebuildTale()">Rebuild Tale</div>
-                                            <div class="item" (click)="restartTale()">Restart Tale</div>
-                                            <div class="item" (click)="copyTale()">Duplicate Tale</div>
-                                            <div class="item" (click)="openPublishTaleDialog($event)">Publish Tale</div>
-                                            <div class="item" (click)="viewFullScreen()">View Fullscreen</div>
-                                            <div class="item" (click)="gotoDocs()">View Documentation</div>
-                                            <div class="item" (click)="exportTale()">Export Tale</div>
+                                            <div class="item" (click)="rebuildTale()"><i class="fas fa-redo-alt"></i> Rebuild Tale</div>
+                                            <div class="item" (click)="restartTale()"><i class="fas fa-sync-alt"></i> Restart Tale</div>
+
+                                            <div class="divider"></div>
+                                            <div class="item" (click)="saveTaleVersion()"><i class="fas fa-save"></i> Save Tale Version</div>
+                                            <div class="item" (click)="performRecordedRun()"><i class="fas fa-check-circle"></i> Recorded Run</div>
+                                            <div class="divider"></div>
+
+                                            <div class="item" (click)="copyTale()"><i class="fas fa-clone"></i> Duplicate Tale</div>
+                                            <div class="item" (click)="openPublishTaleDialog($event)"><i class="fas fa-newspaper"></i> Publish Tale</div>
+                                            <div class="item" (click)="exportTale()"><i class="fas fa-file-archive"></i> Export Tale</div>
+                                            <div class="divider"></div>
+                                            <div class="item" (click)="openConnectGitRepoDialog()"><i class="fab fa-git"></i> Connect to Git Repository...</div>
+                                            <div class="divider"></div>
+
+                                            <div class="item" (click)="viewFullScreen()"><i class="fas fa-expand"></i> View Fullscreen</div>
+                                            <div class="item" (click)="gotoDocs()"><i class="info circle icon"></i> Read the docs</div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -104,7 +104,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
 
           return;
         }
-        
+
         this.tale = tale;
         this.logger.info("Fetched tale:", this.tale);
 
@@ -138,6 +138,18 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.detectCurrentTab();
     }
 
+    performRecordRun() {
+      console.log('Performing recorded run');
+    }
+
+    saveTaleVersion() {
+      console.log('Saving Tale version');
+    }
+
+    openConnectGitRepoDialog() {
+      console.log('Connecting Git repo');
+    }
+
     rebuildTale(): void {
       const params = { id: this.tale._id };
       this.taleService.taleBuildImage(params).subscribe(res => {
@@ -164,7 +176,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       });
     }
 
-      
+
     // Expected parameter format:
     //    dataMap: [{"name":"Elevation per SASAP region and Hydrolic Unit (HUC8) boundary for Alaskan watersheds","dataId":"resource_map_doi:10.5063/F1Z60M87","repository":"DataONE","doi":"10.5063/F1Z60M87","size":10293583}]
     openPublishTaleDialog(event: Event): void {
@@ -172,7 +184,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         data: { tale: this.tale }
       };
       const dialogRef = this.dialog.open(PublishTaleDialogComponent, config);
-      
+
       // Don't do anything on close
     }
 

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -138,7 +138,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.detectCurrentTab();
     }
 
-    performRecordRun() {
+    performRecordedRun() {
       console.log('Performing recorded run');
     }
 


### PR DESCRIPTION
## Problem
Multiple upcoming features will require modifying the dropdown menu to include new or expanded items. 
  
## Approach
Preemptively stub-out upcoming methods to (hopefully) prevent a merge conflict.

* Added icons to the Run view dropdown menu
* Reordered dropdown items to match mockups (slight divergence aside)
  * No "Duplicate Tale" in mockups
  * Only one "Export" option going forward
  * Grouped Duplicate/Publish/Export together for now
* Added new Run view dropdown menu items (currently noops/stubs):
  * Save Tale Version
  * Recorded Run
  * Connect to Git repository


## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
4. Navigate to the Run view for the Tale
5. Expand the dropdown at the top-right of the paddleboard
    * You should see a dropdown menu appear
    * Each dropdown item should have an icon
    * You should see (non-functional) options for features that have not yet been implemented
    * The dropdown menu should very nearly match the mockups, seen [here](https://whole-tale.github.io/wholetale-css-mockup/src/run.html)