### PR TITLE
Handle return route after login

### DIFF
--- a/src/app/api/api.module.ts
+++ b/src/app/api/api.module.ts
@@ -35,6 +35,8 @@ import { TokenInterceptor } from './token.interceptor';
 import { TokenService as JwtTokenService } from './token.service';
 import { NotificationStreamService } from './notification-stream.service';
 
+import { AuthGuard } from './auth-guard';
+
 /**
  * Provider for all Api services, plus ApiConfiguration
  */
@@ -46,6 +48,7 @@ import { NotificationStreamService } from './notification-stream.service';
     ApiConfiguration,
     ApiKeyService,
     AssetstoreService,
+    AuthGuard,
     CollectionService,
     DatasetService,
     DmService,

--- a/src/app/api/auth-guard.ts
+++ b/src/app/api/auth-guard.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot } from '@angular/router';
+
+import { User } from '@api/models/user';
+import { UserService } from '@api/services/user.service';
+
+@Injectable()
+export class AuthGuard implements CanActivateChild {
+  constructor(private readonly router: Router, private readonly userService: UserService) {}
+
+  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    return new Promise<boolean>((resolve, reject) => {
+      this.userService.userGetMe().subscribe(
+        (user: User) => {
+          if (user) {
+            // logged in so return true
+            resolve(true);
+          }
+
+          // not logged in so redirect to login page with the return url and return false
+          this.router.navigate(['login'], { queryParams: { rd: state.url } });
+          return resolve(false);
+        },
+        () => resolve(false)
+      );
+    });
+  }
+}

--- a/src/app/api/auth-guard.ts
+++ b/src/app/api/auth-guard.ts
@@ -3,22 +3,27 @@ import { ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot }
 
 import { User } from '@api/models/user';
 import { UserService } from '@api/services/user.service';
+import { TokenService } from '@api/token.service';
 
 @Injectable()
 export class AuthGuard implements CanActivateChild {
-  constructor(private readonly router: Router, private readonly userService: UserService) {}
+  constructor(private readonly router: Router, private readonly userService: UserService, private readonly tokenService: TokenService) {}
 
   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     return new Promise<boolean>((resolve, reject) => {
       this.userService.userGetMe().subscribe(
         (user: User) => {
-          if (user) {
-            // logged in so return true
-            resolve(true);
-          }
+          const url = state.url.startsWith('/') ? state.url.substring(1) : state.url;
 
           // not logged in so redirect to login page with the return url and return false
-          this.router.navigate(['login'], { queryParams: { rd: state.url } });
+          this.tokenService.setReturnRoute(url);
+
+          if (user) {
+            // logged in so return true
+            return resolve(true);
+          }
+
+          this.router.navigate(['login'], { queryParams: { rd: url } });
           return resolve(false);
         },
         () => resolve(false)

--- a/src/app/api/token.service.ts
+++ b/src/app/api/token.service.ts
@@ -12,6 +12,8 @@ export class TokenService {
   // JWT helper service for checking token expiration
   jwt: JwtHelperService = new JwtHelperService();
 
+  returnRoute: string;
+
   // Cache the user that this token represents (for display)
   user: ReplaySubject<User> = new ReplaySubject<User>();
 
@@ -22,6 +24,21 @@ export class TokenService {
   }
   getToken(): string {
     return localStorage.getItem('girderToken');
+  }
+  clearToken(): void {
+    localStorage.removeItem('girderToken');
+  }
+  setReturnRoute(returnRoute: string) {
+    localStorage.setItem('returnRoute', returnRoute);
+  }
+  getReturnRoute(): string {
+    const route = localStorage.getItem('returnRoute');
+
+    if (route) {
+      return route;
+    } else {
+      return 'public';
+    }
   }
   isAuthenticated(): boolean {
     // get the token

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,4 @@
+import { AuthGuard as CustomAuthGuard } from '@api/auth-guard';
 import { AuthGuard } from '@ngx-auth/core';
 import { MetaGuard } from '@ngx-meta/core';
 import { ChangeLanguageComponent } from '~/app/framework/i18n';
@@ -41,7 +42,7 @@ export const routes = [
         loadChildren: './+user-settings/user-settings.module#UserSettingsModule'
       }
     ],
-    canActivateChild: [MetaGuard, AuthGuard],
+    canActivateChild: [MetaGuard, CustomAuthGuard /*, AuthGuard */],
     data: {
       i18n: {
         isRoot: true

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -76,6 +76,7 @@ export class HeaderComponent extends BaseComponent implements OnInit {
   async logout(): Promise<boolean> {
     this.isAuthenticated = false;
     this.cookies.deleteAll();
+    this.tokenService.clearToken();
 
     return this.auth.invalidate();
   }

--- a/src/app/shared/error-handler/server-error.interceptor.ts
+++ b/src/app/shared/error-handler/server-error.interceptor.ts
@@ -16,8 +16,9 @@ export class ServerErrorInterceptor implements HttpInterceptor {
       catchError((error: HttpErrorResponse) => {
         if (error.status === 401) {
           // refresh token plz
+          const lastRoute = encodeURIComponent(window.origin);
           this.auth.invalidate().then(resp => {
-            this.router.navigate(['login']);
+            this.router.navigate(['login', { queryParams: { rd: lastRoute } }]);
           });
         } else {
           return throwError(error);


### PR DESCRIPTION
## Problem
When an unauthenticated user accesses the WholeTale Dashboard, they are bounced to the login page. After login, they are dropped at the home page. This breaks the user's flow by requiring them to manually navigate back to their desired view.
  
Fixes #34 

## Approach
Save `returnRoute` as a query string parameter when bouncing a user to the login page, and use this query param to restore their navigation target after login.
  
## How to Test
Prerequisites: Logout

1. Checkout this branch locally, rebuild the dashboard
2. Attempt to navigate to `/mine` without logging in
    * You should be bounced to the login page
    * You should see `?rd=mine` in the query string parameter
3. Login with the correct credentials
    * You should be brought to the My Tales (`/mine`) view
