### PR TITLE
Fix Settings view redirect URL to use origin 

### DIFF
--- a/src/app/+user-settings/configure-accounts/configure-accounts.component.ts
+++ b/src/app/+user-settings/configure-accounts/configure-accounts.component.ts
@@ -95,7 +95,7 @@ export class ConfigureAccountsComponent extends BaseComponent implements OnInit 
   }
   
   refreshProviders(): void {
-    const redirect = 'https://next.local.wholetale.org/settings';
+    const redirect = `${window.origin}/settings`;
     const params = { redirect };
     this.accountService.accountListAccounts(params).subscribe((accts: Array<Account>) => {
       this.providers = accts;


### PR DESCRIPTION
## Problem
Fixes #58 

## Approach
Use origin instead of a hard-coded URL

## How to Test
Prerequisites: Disconnect DataONE account

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Settings view
4. Disconnect DataONE account, if you haven't already
5. Click "Connect Account" beside DataONE in the list
6. Sign in with OAuth, if necessary
  * You should be redirected to the Settings view (your original starting location)
