### PR TITLE
Set required Tale fields to non-null default values

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -31,7 +31,7 @@ enum TaleExportFormat {
 })
 export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges {
     taleId: string;
-    tale: Tale = { title:'???', authors: [], imageId: '', dataSet: [], publishInfo: [] };
+    tale: Tale = { title:'???', authors: [], imageId: '', category: '', license: 'CC-BY-4.0', dataSet: [], description: '', public: false, publishInfo: []  };
     instance: Instance;
     creator: User;
     currentTab = 'metadata';
@@ -104,7 +104,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
 
           return;
         }
-        
+
         this.tale = tale;
         this.logger.info("Fetched tale:", this.tale);
 
@@ -164,7 +164,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       });
     }
 
-      
+
     // Expected parameter format:
     //    dataMap: [{"name":"Elevation per SASAP region and Hydrolic Unit (HUC8) boundary for Alaskan watersheds","dataId":"resource_map_doi:10.5063/F1Z60M87","repository":"DataONE","doi":"10.5063/F1Z60M87","size":10293583}]
     openPublishTaleDialog(event: Event): void {
@@ -172,7 +172,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         data: { tale: this.tale }
       };
       const dialogRef = this.dialog.open(PublishTaleDialogComponent, config);
-      
+
       // Don't do anything on close
     }
 

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -21,7 +21,14 @@ export class CreateTaleModalComponent implements OnInit {
     this.newTale = {
       title: (data && data.params) ? data.params.name : '',
       imageId: '',
-      dataSet: []
+      authors: [],
+      license: 'CC-BY-4.0',
+      category: 'science',
+      publishInfo: [],
+      dataSet: [],
+      public: false,
+      copyOfTale: null,
+      description: '### Provide a description for your Tale'
     };
   }
 

--- a/src/app/api/models/tale.ts
+++ b/src/app/api/models/tale.ts
@@ -3,6 +3,7 @@ import { ContainerConfig } from './container-config';
 import { DataSet } from './data-set';
 import { ImageInfo } from './image-info';
 import { PublishInfo } from './publish-info';
+import { TaleAuthor } from '@tales/models/tale-author';
 
 /**
  * Object representing a Tale.
@@ -32,7 +33,7 @@ export interface Tale {
   /**
    * Keyword describing topic of the Tale
    */
-  category?: string;
+  category: string;
   config?: ContainerConfig;
 
   /**
@@ -54,7 +55,7 @@ export interface Tale {
   /**
    * The description of the Tale (Markdown)
    */
-  description?: string;
+  description: string;
 
   /**
    * ID of a folder containing copy of tale['dataSet']
@@ -74,7 +75,7 @@ export interface Tale {
   /**
    * A list of authors that are associated with the Tale
    */
-  authors?: Array<{}>;
+  authors: Array<TaleAuthor>;
 
   /**
    * A URL to an image depicturing the content of the Tale
@@ -90,7 +91,7 @@ export interface Tale {
   /**
    * The license that the Tale is under
    */
-  license?: string;
+  license: string;
 
   /**
    * List of Girder Items containing Tale's narrative
@@ -105,8 +106,8 @@ export interface Tale {
   /**
    * If set to true the Tale is accessible by anyone.
    */
-  public?: boolean;
-  publishInfo?: Array<PublishInfo>;
+  public: boolean;
+  publishInfo: Array<PublishInfo>;
 
   /**
    * Title of the Tale


### PR DESCRIPTION
## Problem
After creating a Tale, editing/saving metadata does not work properly because some of the fields of the new Tale are invalid by default.

Fixes #32 
  
## Approach
Default all required fields to reasonable defaults.

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a new Tale
    * You should be redirected to the Run > Metadata view for the Tale
4. Scroll down and click the "Edit" button at the bottom
    * An editable form should appear
5. Scroll down and click the "Save" button at the bottom
    * You should receive a toast / popup saying your Tale was saved successfully
