### PR TITLE
Reword Rename dialog to cover both files and folders

### DIFF
--- a/src/app/files/file-explorer/modals/rename-dialog/rename-dialog.component.html
+++ b/src/app/files/file-explorer/modals/rename-dialog/rename-dialog.component.html
@@ -1,9 +1,9 @@
-<h1 mat-dialog-title>Rename Element</h1>
+<h1 mat-dialog-title>Rename Item</h1>
 
 <mat-dialog-content>
   <form class="ui form">
     <div class="field">
-      <input matInput type="text" name="folder-name" placeholder="Folder Name" [(ngModel)]="folderName" required />
+      <input matInput type="text" name="item-name" placeholder="Item Name" [(ngModel)]="itemName" required />
     </div>
     <!--<button class="ui button" type="submit">Submit</button>-->
   </form>
@@ -11,7 +11,7 @@
 
 <mat-dialog-actions>
   <button class="ui black deny button" mat-dialog-close>Cancel</button>
-  <button class="ui positive right labeled icon button" [mat-dialog-close]="folderName">
+  <button class="ui positive right labeled icon button" [mat-dialog-close]="itemName">
     Submit
     <i class="checkmark icon"></i>
   </button>

--- a/src/app/files/file-explorer/modals/rename-dialog/rename-dialog.component.ts
+++ b/src/app/files/file-explorer/modals/rename-dialog/rename-dialog.component.ts
@@ -5,5 +5,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./rename-dialog.component.scss']
 })
 export class RenameDialogComponent {
-  folderName = '';
+  itemName = '';
 }


### PR DESCRIPTION
## Problem
The rename dialog has the word "folder" hard-coded in it. This is obviously confusing when it appears to rename a file.

Fixes #38 

## Approach
Reword dialog to say "item" instead of "folder", which should cover both cases.

## How to Test
Prerequisites: at least one Tale created, at least one file uploaded

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
    * You should be brought to the Run view
4. Navigate to Run > Files > Home
5. Upload a file, if you haven't already
6. Expand the dropdown beside the file and choose "Rename"
    * The `rename-dialog` should appear
    * The prompt should now say `Item Name` instead of `Folder Name`
