### PR TITLE
Added working search box to tale-catalog

### DIFF
--- a/src/app/+tale-catalog/tale-catalog.module.ts
+++ b/src/app/+tale-catalog/tale-catalog.module.ts
@@ -16,6 +16,7 @@ import { MyTalesPipe } from './tale-catalog/pipes/my-tales.pipe';
 import { PublicTalesPipe } from './tale-catalog/pipes/public-tales.pipe';
 import { RunningTalesPipe } from './tale-catalog/pipes/running-tales.pipe';
 import { StoppedTalesPipe } from './tale-catalog/pipes/stopped-tales.pipe';
+import { SearchTalesPipe } from './tale-catalog/pipes/search-tales.pipe';
 import { TaleCatalogComponent } from './tale-catalog/tale-catalog.component';
 
 @NgModule({
@@ -30,7 +31,8 @@ import { TaleCatalogComponent } from './tale-catalog/tale-catalog.component';
     PublicTalesPipe,
     MyTalesPipe,
     StoppedTalesPipe,
-    RunningTalesPipe
+    RunningTalesPipe,
+    SearchTalesPipe
   ],
   entryComponents: [CreateTaleModalComponent, DeleteTaleModalComponent],
 })

--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -1,21 +1,35 @@
 
 <!-- My Tales -->
 <div *ngIf="(tales$ | async) as taleList">
-  
+
+    <!-- Search Tales -->
+    <div class="row">
+        <div class="sixteen wide column">
+            <div class="ui fluid icon wt-input input">
+                <input type="text" placeholder="Search Tales..." [(ngModel)]="searchQuery">
+                <i class="search icon"></i>
+            </div>
+        </div>
+    </div>
+
   <!-- Running Tales -->
-  <div class="row">
-    <div class="sixteen wide column">
-  
-      <div class="ui message" *ngIf="!(taleList | myTales:user | running:instances).length">
+  <div class="row" *ngIf="(taleList | myTales:user | running:instances) as allRunningTales">
+    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchFilter:creators | myTales:user | running:instances) as filteredRunningTales">
+
+      <div class="ui message" *ngIf="!allRunningTales.length">
           You do not have any running Tales.
       </div>
-  
-      <div class="ui message" *ngIf="(taleList | myTales:user | running:instances).length">
-  
-        <p style="margin:0 0 15px;"><b>Currently running:</b> <i>{{ instanceCount }} Tales (out of 2 maximum)</i></p> 
-  
+
+      <div class="ui message" *ngIf="allRunningTales.length && !filteredRunningTales.length">
+          No running Tales matched your search query ({{ allRunningTales.length }} currently hidden).
+      </div>
+
+      <div class="ui message" *ngIf="allRunningTales.length && filteredRunningTales.length">
+
+        <p style="margin:0 0 15px;"><b>Currently running:</b> <i>{{ instanceCount }} Tale<span *ngIf="instanceCount > 1">s</span> (<span *ngIf="filteredRunningTales.length !== allRunningTales.length">{{ runningTales.length - filteredRunningTales.length }} currently hidden, </span>of 2 maximum)</i></p>
+
         <div class="ui two stackable doubling selectable special cards">
-          <div class="ui card" *ngFor="let tale of (taleList | myTales:user | running:instances); index as i; trackBy: trackById">
+          <div class="ui card" *ngFor="let tale of filteredRunningTales; index as i; trackBy: trackById">
             <div class="extra content">
               <span style="text-transform:uppercase">
                 {{ tale.copyOfTale ? 'copy' : 'original' }}
@@ -29,7 +43,7 @@
                   </div>
                 </div>
               </div>
-  
+
               <!-- Illustration and Logo -->
               <!-- TODO: Fix compute environment logo -->
               <img class="pic" [src]="tale.illustration" alt="Research image">
@@ -61,24 +75,28 @@
             </div>
           </div>
         </div>
-  
+
       </div>
-  
+
     </div>
   </div>
 
-  <div class="row" style="margin-top:40px;margin-bottom:30px;">
-    <div class="sixteen wide column">
-  
+  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(taleList | myTales:user | stopped:instances) as allStoppedTales">
+    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchQuery:creators | myTales:user | stopped:instances) as filteredStoppedTales">
+
       <!-- Placeholder Message -->
-      <div class="ui message" *ngIf="!(taleList | myTales:user | stopped:instances).length">
+      <div class="ui message" *ngIf="!allStoppedTales.length">
           You do not have any stopped Tales.
       </div>
-  
-      <div class="ui four stackable doubling selectable special cards">
-  
+
+      <div class="ui message" *ngIf="allStoppedTales.length && !filteredStoppedTales.length">
+          No stopped Tales matched your search query.
+      </div>
+
+      <div class="ui four stackable doubling selectable special cards" *ngIf="allStoppedTales.length && filteredStoppedTales.length">
+
         <!-- Card for each Tale -->
-        <div class="ui card" *ngFor="let tale of (taleList | myTales:user | stopped:instances); index as i; trackBy: trackById">
+        <div class="ui card" *ngFor="let tale of filteredStoppedTales; index as i; trackBy: trackById">
           <div class="extra content">
             <div class="right floated meta" (click)="openDeleteTaleModal(tale)"><i class="close icon"></i></div>
             <span style="text-transform:uppercase">
@@ -86,7 +104,7 @@
             </span>
           </div>
           <div class="blurring dimmable segment fluid image" id="{{ tale._id }}-dimmer" (mouseover)="showDimmer(tale)" (mouseout)="hideDimmer(tale)">
-  
+
             <!-- Abstract card into reusable template? Card component? -->
             <div class="ui dimmer transition hidden">
               <div class="content">
@@ -98,7 +116,7 @@
                 </div>
               </div>
             </div>
-  
+
             <!-- Illustration and Logo -->
             <!-- TODO: Fix compute environment logo -->
             <img class="pic" [src]="tale.illustration" alt="Research image">
@@ -106,7 +124,7 @@
               <img [src]="tale.icon" width="80" style="width: 80px;" alt="Compute Icon">
             </span>
           </div>
-  
+
           <div class="content">
             <div style="text-transform: uppercase; color: #ba975e;font-weight: 700;">
                 {{ tale.categories }}
@@ -131,7 +149,7 @@
           </div>
         </div>
       </div>
-  
+
     </div>
   </div>
 </div>

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
@@ -1,20 +1,35 @@
 
 <!-- Public Tales -->
-<div  *ngIf="(tales$ | async) as taleList">
+<div *ngIf="(tales$ | async) as taleList">
+
+    <!-- Search Tales -->
+    <div class="row">
+        <div class="sixteen wide column">
+            <div class="ui fluid icon wt-input input">
+                <input type="text" placeholder="Search Tales..." [(ngModel)]="searchQuery">
+                <i class="search icon"></i>
+            </div>
+        </div>
+    </div>
+
   <!-- Running Tales -->
-  <div class="row">
-    <div class="sixteen wide column">
-  
-      <div class="ui message" *ngIf="!(taleList | myTales:user | running:instances).length">
+  <div class="row" *ngIf="(taleList | myTales:user | running:instances) as allRunningTales">
+    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchQuery:creators | myTales:user | running:instances) as filteredRunningTales">
+
+      <div class="ui message" *ngIf="!allRunningTales.length">
           You do not have any running Tales.
       </div>
-  
-      <div class="ui message" *ngIf="(taleList | myTales:user | running:instances).length">
-  
-        <p style="margin:0 0 15px;"><b>Currently running:</b> <i>{{ instanceCount }} Tales (out of 2 maximum)</i></p> 
-  
+
+      <div class="ui message" *ngIf="allRunningTales.length && !filteredRunningTales.length">
+          No running Tales matched your search query ({{ allRunningTales.length }} currently hidden).
+      </div>
+
+      <div class="ui message" *ngIf="allRunningTales.length && filteredRunningTales.length">
+
+        <p style="margin:0 0 15px;"><b>Currently running:</b> <i>{{ instanceCount }} Tales (<span *ngIf="filteredRunningTales.length !== allRunningTales.length">{{ runningTales.length - filteredRunningTales.length }} currently hidden, </span>of 2 maximum)</i></p>
+
         <div class="ui two stackable doubling selectable special cards">
-          <div class="ui card" *ngFor="let tale of (taleList | myTales:user | running:instances); index as i; trackBy: trackById">
+          <div class="ui card" *ngFor="let tale of filteredRunningTales; index as i; trackBy: trackById">
             <div class="extra content">
               <span style="text-transform:uppercase">
                 {{ tale.copyOfTale ? 'copy' : 'original' }}
@@ -28,7 +43,7 @@
                   </div>
                 </div>
               </div>
-  
+
               <!-- Illustration and Logo -->
               <!-- TODO: Fix compute environment logo -->
               <img class="pic" [src]="tale.illustration" alt="Research image">
@@ -60,25 +75,29 @@
             </div>
           </div>
         </div>
-  
+
       </div>
-  
+
     </div>
   </div>
-  
-  <div class="row" style="margin-top:40px;margin-bottom:30px;">
-    <div class="sixteen wide column">
-  
-      <div class="ui message" *ngIf="!(taleList | publicTales).length">
+
+  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(taleList | publicTales) as allPublicTales">
+    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchQuery:creators | publicTales) as filteredPublicTales">
+
+      <div class="ui message" *ngIf="!allPublicTales.length">
           No Public Tales have been shared.
       </div>
-  
-  		<div class="ui four stackable doubling selectable special cards">
-  
+
+      <div class="ui message" *ngIf="allPublicTales.length && !filteredPublicTales.length">
+          No Public Tales matched your search query.
+      </div>
+
+  	  <div class="ui four stackable doubling selectable special cards" *ngIf="allPublicTales.length && filteredPublicTales.length">>
+
         <!-- Card for each Tale -->
-        <div class="ui card" *ngFor="let tale of (taleList | publicTales); index as i; trackBy: trackById">
+        <div class="ui card" *ngFor="let tale of filteredPublicTales; index as i; trackBy: trackById">
           <div class="blurring dimmable segment fluid image" id="{{ tale._id }}-dimmer" (mouseover)="showDimmer(tale)" (mouseout)="hideDimmer(tale)">
-  
+
             <!-- Abstract card into reusable template? Card component? -->
             <div class="ui dimmer transition hidden">
               <div class="content">

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, NgZone, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, NgZone, OnChanges, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
@@ -22,13 +22,15 @@ declare var $: any;
   styleUrls: ['./public-tales.component.scss'],
   selector: 'app-public-tales'
 })
-export class PublicTalesComponent implements OnInit {
+export class PublicTalesComponent implements OnChanges, OnInit {
   tales$: Observable<Array<Tale>> = new Observable<Array<Tale>>();
   tales: Array<Tale> = [];
   publicTales: Array<Tale> = [];
 
+  searchQuery = '';
+
   user: User;
-  
+
   get instanceCount(): number {
     return Object.keys(this.instances).length;
   }
@@ -52,6 +54,10 @@ export class PublicTalesComponent implements OnInit {
     this.userService.userGetMe().subscribe(user => {
       this.user = user;
     });
+    this.refresh();
+  }
+
+  ngOnChanges(): void {
     this.refresh();
   }
 
@@ -95,6 +101,7 @@ export class PublicTalesComponent implements OnInit {
     // Fetch the list of public tales
     const listTalesParams = {};
     this.taleService.taleListTales(listTalesParams).subscribe((tales: Array<Tale>) => {
+      // Filter based on search query
       this.tales = tales;
       this.ref.detectChanges();
 
@@ -116,7 +123,7 @@ export class PublicTalesComponent implements OnInit {
     const dialogRef = this.dialog.open(DeleteTaleModalComponent);
     dialogRef.afterClosed().subscribe(result => {
       if (!result) { return; }
-      
+
       const id = tale._id;
       this.taleService.taleDeleteTale({ id }).subscribe(response => {
         this.logger.debug("Successfully deleted Tale:", response);

--- a/src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
+++ b/src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
@@ -1,0 +1,55 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Tale } from '@api/models/tale';
+import { User } from '@api/models/user';
+import { TaleAuthor } from '@tales/models/tale-author';
+import { TokenService } from '@api/token.service';
+
+import { LogService } from '@framework/core/log.service';
+
+// Given a list of tales, returns only tales that were created by the current user
+@Pipe({name: 'searchTales'})
+export class SearchTalesPipe implements PipeTransform {
+  constructor(private tokenService: TokenService, private logger: LogService) {  }
+
+  transform(value: Array<Tale>, searchQuery: string, creators: Map<string, User>): Array<Tale> {
+    // Short-circuit for null case(s)
+    if (!searchQuery || !value || !value.length) {
+      return value;
+    }
+
+    const filteredTales: Array<Tale> = [];
+    value.forEach((tale: Tale) => {
+      // Check title / description / creator first (should catch 99% of cases)
+      if (tale.title && tale.title.includes(searchQuery)) {
+        this.logger.info("Found in title: ", tale.title);
+        filteredTales.push(tale);
+      } else if (tale.description && tale.description.includes(searchQuery)) {
+        this.logger.info("Found in description: ", tale.description);
+        filteredTales.push(tale);
+      } else if (tale._id && creators && creators[tale._id] && creators[tale._id].name
+            && creators[tale._id].name.includes(searchQuery)) {
+        this.logger.info("Found in creator name: ", creators[tale._id].name);
+        filteredTales.push(tale);
+      } else {
+        this.logger.info("Query not found in title/description/creator, searching authors ", tale);
+
+        // Otherwise, check authors exhaustively
+        if (tale.authors.some((author: TaleAuthor) => {
+          const firstNameContains = author.firstName && author.firstName.includes(searchQuery);
+          const lastNameContains = author.lastName && author.lastName.includes(searchQuery);
+          const orcidContains = author.orcid && author.orcid.includes(searchQuery);
+          const result = firstNameContains || lastNameContains || orcidContains;
+
+          return result;
+        })) {
+          this.logger.info(`Found in author`, tale);
+          filteredTales.push(tale);
+        } else {
+          this.logger.debug(`Search query does not match this Tale`, tale);
+        }
+      }
+    });
+
+    return filteredTales;
+  }
+}

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
@@ -23,15 +23,6 @@
 			</div>
 		</div>
 
-    <!-- Search Tales -->
-		<div class="row">
-			<div class="sixteen wide column">
-				<div class="ui fluid icon wt-input input">
-					<input type="text" placeholder="Search Tales..." [(ngModel)]="searchQuery">
-					<i class="search icon"></i>
-				</div>
-			</div>
-		</div>
 
     <!-- Sub-view changes based on URL -->
     <div class="row">

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -16,7 +16,6 @@ import { CreateTaleModalComponent } from './modals/create-tale-modal/create-tale
 })
 export class TaleCatalogComponent extends BaseComponent implements AfterViewInit {
     currentPath = "tales";
-    searchQuery = '';
 
     @Output() readonly taleCreated = new EventEmitter<Tale>();
 
@@ -67,7 +66,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
               });
             });
           });
-          
+
         }
       }, 1000);
     }


### PR DESCRIPTION
## Problem
Search box on the `tale-catalog` view is currently just a placeholder.

Fixes #35 
  
## Approach
Implement the search function in the "Public Tales" and "My Tales" views

My assumption (because the search box is above the "Running Tales" section of the UI) was that the search filter should affect Running Tales as well. If this was incorrect, I can adjust it so that the search only affects the lower section (but would likely also opt to move the search box in this case).

## How to Test
Prerequisites: several Tales created, LIGO Tale added (public), one or more Tales running

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Click `Tale Catalog` in the navbar
    * You should be brought to the "Public Tales" view
4. Enter "LIGO" into the search box
    * All but the LIGO Tale should be hidden
    * You should see that your running Tales are filtered as well
5. Click on the "My Tales" tab
    * You should be brought to the "My Tales" view
6. Enter a search term here as well (to verify that search works in both contexts)
    * You should see Tales are filtered here as well based on search
    * You should see your running Tales are filtered as well