### PR TITLE
Export Tale should download a zipfile

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -14,6 +14,8 @@ import { enterZone } from '@framework/ngrx/enter-zone.operator';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { routeAnimation } from '~/app/shared';
 
+import { ApiConfiguration } from '@api/api-configuration';
+import { TokenService } from '@api/token.service';
 import { PublishTaleDialogComponent } from './modals/publish-tale-dialog/publish-tale-dialog.component';
 
 // import * as $ from 'jquery';
@@ -46,6 +48,8 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       private taleService: TaleService,
       private instanceService: InstanceService,
       private userService: UserService,
+      private tokenService: TokenService,
+      private config: ApiConfiguration,
       private dialog: MatDialog
     ) {
         super();
@@ -202,9 +206,8 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     }
 
     exportTale(format: TaleExportFormat = TaleExportFormat.BagIt): void {
-      const params = { id: this.tale._id, taleFormat: format };
-      this.taleService.taleExportTale(params).subscribe(res => {
-        this.logger.debug(`Exporting tale=${this.tale._id} to ${format}`, res);
-      });
+      const token = this.tokenService.getToken();
+      const url = `${this.config.rootUrl}/tale/${this.tale._id}/export?token=${token}&taleFormat=${format}`;
+      window.open(url, '_blank');
     }
 }

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -208,6 +208,6 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     exportTale(format: TaleExportFormat = TaleExportFormat.BagIt): void {
       const token = this.tokenService.getToken();
       const url = `${this.config.rootUrl}/tale/${this.tale._id}/export?token=${token}&taleFormat=${format}`;
-      window.open(url, '_blank');
+      this.windowService.open(url, '_blank');
     }
 }

--- a/src/app/framework/core/models/window.ts
+++ b/src/app/framework/core/models/window.ts
@@ -3,6 +3,6 @@ export interface Window {
   location: any;
 
   alert(msg: string): void;
-
+  open(url: string, target?: string): void;
   confirm(msg: string): void;
 }

--- a/src/app/framework/core/window.service.ts
+++ b/src/app/framework/core/window.service.ts
@@ -4,6 +4,10 @@ export class WindowService implements Window {
   navigator: any = {};
   location: any = {};
 
+  open(url: string, target?: string) {
+    return;
+  }
+
   alert(msg: string): void {
     return;
   }


### PR DESCRIPTION
## Problem
When a user chooses "Export Tale" from the UI, nothing happens. This is because the `tale/:id/export` does not follow the same patterns as the other endpoints, and requires special handling.
  
Fixes #49 

## Approach
Handle this endpoint by navigating to it directly in the browser. This requires placing our token in the URL as a query parameter.

## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. From the Tale Catalog view, hover over a Tale and click "View"
    * You should be brought to the Run view
4. At the top-right, expand the dropdown and choose "Export Tale"
    * You may see a new tab open and then immediately close
    * You should see that a download has started for a ZIP file named after the Tale ID 
