### PR TITLE
Navigate to Run > Interact view on launch

### DIFF
--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, NgZone, Output } from '@angular/core';
 import { MatDialog } from '@angular/material';
+import { Router } from '@angular/router';
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
 import { InstanceService } from '@api/services/instance.service';
@@ -28,6 +29,7 @@ export class TaleRunButtonComponent {
     private readonly zone: NgZone,
     private readonly dialog: MatDialog,
     private readonly logger: LogService,
+    private readonly router: Router,
     private readonly taleService: TaleService,
     private readonly instanceService: InstanceService
   ) {}
@@ -52,6 +54,7 @@ export class TaleRunButtonComponent {
           this.instance = instance;
           this.taleInstanceStateChanged.emit(this.tale);
           // this.refilter();
+          this.router.navigate(['run', this.tale._id], { queryParams: { tab: 'interact' } });
 
           // Poll / wait for launch
           // TODO: Fix edge cases (refresh, etc)


### PR DESCRIPTION
## Problem
When launching a Tale, the user is not brought to the Interact tab as expected.

Fixes #45 
  
## Approach
Navigate to the Run > Interact view when launching a Tale.
 
## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog
4. Choose a Tale and click "Run Tale"
    * You should be navigated to the Run > Interact view
5. Stop the Tale and navigate to the Run > Metadata view
6. Click "Run Tale" again
    * You should be navigated to the Run > Interact view