### PR TITLE
Truncate Tale title throughout

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -18,8 +18,8 @@
                                     <div class="title-info">
                                         <img [src]="tale.illustration" *ngIf="tale.illustration">
                                         <img [src]="tale.icon" class="env" *ngIf="tale.icon">
-                                        <p>{{ tale.title }}</p>
-                                        
+                                        <p>{{ tale.title | truncate:100 }}</p>
+
                                         <p class="qualifier">
                                             <span *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorOrcid">
                                                 <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>

--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -56,7 +56,9 @@
                 {{ tale.categories }}
               </div>
               <div class="t-title">
-                <h3>{{ tale.title }}</h3>
+                <h3 [title]="tale.title">
+                    <a class="ui link" style="text-decoration:none;" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'interact'}" routerLinkActive="active">{{ tale.title | truncate:truncateLength }}</a>
+                </h3>
               </div>
               <div>
                   by
@@ -130,7 +132,9 @@
                 {{ tale.categories }}
             </div>
             <div class="t-title">
-              <h3>{{ tale.title }}</h3>
+                <h3 [title]="tale.title">
+                    <a class="ui link" style="text-decoration:none;" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'metadata'}" routerLinkActive="active">{{ tale.title | truncate:truncateLength }}</a>
+                </h3>
             </div>
             <div>
                 by

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
@@ -56,7 +56,10 @@
                 {{ tale.categories }}
               </div>
               <div class="t-title">
-                <h3>{{ tale.title }}</h3>
+
+                <h3 [title]="tale.title">
+                    <a class="ui link" style="text-decoration:none;" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'interact'}" routerLinkActive="active">{{ tale.title | truncate:truncateLength }}</a>
+                </h3>
               </div>
               <div>
                   by
@@ -102,7 +105,7 @@
             <div class="ui dimmer transition hidden">
               <div class="content">
                 <div class="center">
-                  <a class="ui inverted button" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'metadata'}" routerLinkActive="active">View</a>
+                  <a class="ui inverted button" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'interact'}" routerLinkActive="active">View</a>
                   <a class="ui tiny bottom right attached label" (click)="openDeleteTaleModal(tale)" *ngIf="tale._accessLevel > 1">
                       <i class="red remove icon"></i>
                   </a>
@@ -119,8 +122,8 @@
                 {{ tale.categories }}
             </div>
             <div class="t-title">
-              <h3>
-                <a class="ui link" style="text-decoration:none;" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'metadata'}" routerLinkActive="active">{{ tale.title }}</a>
+              <h3 [title]="tale.title">
+                <a class="ui link" style="text-decoration:none;" [routerLink]="'/run/' + tale._id" [queryParams]="{ tab: 'metadata'}" routerLinkActive="active">{{ tale.title | truncate:truncateLength }}</a>
               </h3>
             </div>
             <div>

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -27,6 +27,8 @@ export class PublicTalesComponent implements OnChanges, OnInit {
   tales: Array<Tale> = [];
   publicTales: Array<Tale> = [];
 
+  protected truncateLength = 100;
+
   searchQuery = '';
 
   user: User;

--- a/src/app/notification-stream/notification-stream.component.html
+++ b/src/app/notification-stream/notification-stream.component.html
@@ -13,7 +13,7 @@
       <td width="20%"><label class="ui label">{{ event.data.title || event.type }}</label></td>
 
       <!-- TODO: Truncate name -->
-      <td width="30%" *ngIf="event.data.resource.tale_title">{{ event.data.resource.tale_title }}</td>
+      <td width="30%" *ngIf="event.data.resource.tale_title" [title]="event.data.resource.tale_title">{{ event.data.resource.tale_title | truncate:20 }}</td>
       <td width="40%" [ngSwitch]="event.data.state">
         <div class="ui small teal indicating progress event-progress nomargin" *ngSwitchCase="'active'">
           <div id="event-progress-{{ event._id }}" class="ui progress">
@@ -36,7 +36,8 @@
         </span>
       </td>
       <td width="10%">
-          <button (click)="openLogViewerModal(event)" class="ui tiny primary basic right floated button">
+          <button (click)="openLogViewerModal(event)" [disabled]="!event.data.resource || !event.data.resource.jobs || !event.data.resource.jobs.length"
+                class="ui tiny primary basic right floated button">
             View Logs
           </button>
 

--- a/src/app/shared/common/common.module.ts
+++ b/src/app/shared/common/common.module.ts
@@ -7,11 +7,13 @@ import { LoadingOverlayComponent } from './components/loading-overlay/loading-ov
 import { MenuGroupComponent } from './components/menu/menu-group.component';
 import { MenuItemComponent } from './components/menu/menu-item.component';
 
+import { TruncatePipe } from './pipes/truncate.pipe';
+
 const COMPONENTS = [LoadingOverlayComponent, MenuGroupComponent, MenuItemComponent];
 
 @NgModule({
   imports: [CommonAngularModule, FormsModule, MaterialModule],
-  declarations: [COMPONENTS],
-  exports: [CommonAngularModule, COMPONENTS]
+  declarations: [COMPONENTS, TruncatePipe],
+  exports: [CommonAngularModule, COMPONENTS, TruncatePipe]
 })
 export class CommonModule {}

--- a/src/app/shared/common/pipes/truncate.pipe.ts
+++ b/src/app/shared/common/pipes/truncate.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+// Given a string, truncate it to the provided maximum length
+@Pipe({ name: 'truncate' })
+export class TruncatePipe implements PipeTransform {
+  constructor() {}
+
+  transform(value: string, maxLength = 35): string {
+    if (!value) {
+      return '';
+    }
+
+    if (value.length <= maxLength) {
+      return value;
+    }
+
+    return `${value.slice(0, maxLength - 1)}...`;
+  }
+}


### PR DESCRIPTION
## Problem
Tale title is not currently truncated, which can cause UI elements to be too long and extend off the screen.

Fixes #14 
  
## Approach
Added a reusable `TruncatePipe`
  
## How to Test
Prerequisites: at least one Tale created with a long name (100+characters)

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog
    * You should see that the Tale's long name has been truncated
4. Click "View" on the Tale
    * You should be navigated to the Run > Metadata view
    * You should see that the Tale title at the top is now truncated
5. Stop (if necessary), and then Run the Tale
    * You should see the notification panel automatically display with a new notification
    * You should see that the new notification also contains a truncated Tale title