### PR TITLE
Tale popout button

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -74,7 +74,7 @@
                           Metadata
                         </a>
 
-                        <a *ngIf="instance" id="popout-link" class="right floated item" [href]="instance.url" target="_blank">
+                        <a *ngIf="instance && instance.status === 1" id="popout-link" class="right floated item" [href]="instance.url" target="_blank">
                             <i class="fas fa-fw fa-external-link-alt"></i>
                         </a>
                     </div>

--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -19,7 +19,7 @@
                                         <img [src]="tale.illustration" *ngIf="tale.illustration">
                                         <img [src]="tale.icon" class="env" *ngIf="tale.icon">
                                         <p>{{ tale.title }}</p>
-                                        
+
                                         <p class="qualifier">
                                             <span *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorOrcid">
                                                 <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>
@@ -72,6 +72,10 @@
                         </a>
                         <a class="item" [ngClass]="{ 'active': isTabActive('metadata') }" (click)="switchTab('metadata')">
                           Metadata
+                        </a>
+
+                        <a *ngIf="instance" id="popout-link" class="right floated item" [href]="instance.url" target="_blank">
+                            <i class="fas fa-fw fa-external-link-alt"></i>
                         </a>
                     </div>
                     <div class="wt-panel-body" style="padding-bottom:40px" [ngSwitch]="currentTab">

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -20,3 +20,7 @@
   display: inline-block;
   margin-right: 10px;
 }
+
+#popout-link > i {
+  color: #4183c4;
+}

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -59,9 +59,13 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         return author.orcid;
     }
 
-    taleInstanceStateChanged(event: any): void {
-      // this.instance = event;
-      this.refresh();
+    taleInstanceStateChanged(event: {tale: Tale, instance: Instance}): void {
+      if (!event.tale) {
+        return;
+      } else if (event.tale._id === this.tale._id) {
+        this.instance = event.instance;
+      }
+      this.ref.detectChanges();
     }
 
     detectCurrentTab(): void {

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
@@ -6,9 +6,29 @@
     <a class="ui button primary" href="tale.instance.url" target="_blank">Click here to comply</a>
 </div>
 -->
+<pre *ngIf="instance">{{ instance.status }}</pre>
+
 <div class="ui stretched stackable grid" id="tale-interact-container">
   <div class="sixteen wide column" *ngIf="instance">
-    <iframe height="500px" width="100%" [src]="instance.url | safe:'url'" *ngIf="instance && instance.url"></iframe>
+    <!-- Launching state -->
+    <div *ngIf="instance.status === 0" style="margin-top:10vh;text-align:center;">
+      <h3>Tale is launching, please wait...</h3>
+      <i class="fas fa-5x fa-spinner fa-pulse"></i>
+    </div>
+
+    <!-- Running state -->
+    <iframe height="500px" width="100%" [src]="instance.url | safe:'url'" *ngIf="instance.status === 1"></iframe>
+
+    <!-- Error state -->
+    <div *ngIf="instance.status === 2" style="margin-top:10vh;text-align:center;">
+      <i style="margin-top:10vh" class="fas fa-warning"></i>
+    </div>
+
+    <!-- Deleting state -->
+    <div *ngIf="instance.status === 3" style="margin-top:10vh;text-align:center;">
+      <h3>Tale is stopping, please wait...</h3>
+      <i style="margin-top:10vh" class="fas fa-5x fa-trash fa-spin"></i>
+    </div>
   </div>
 
   <div class="sixteen wide column" *ngIf="!instance">

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -61,7 +61,7 @@ export class PublicTalesComponent implements OnChanges, OnInit {
     this.refresh();
   }
 
-  taleInstanceStateChanged(event: any): void {
+  taleInstanceStateChanged(updated: {tale: Tale, instance: Instance}): void {
     this.refresh();
   }
 
@@ -92,7 +92,8 @@ export class PublicTalesComponent implements OnChanges, OnInit {
     this.instanceService.instanceListInstances(listInstancesParams).subscribe((instances: Array<Instance>) => {
       this.zone.run(() => {
         // Convert array to map of taleId -> instance
-        this.instances = Object.assign({}, ...instances.map(i => ({[i.taleId]: i})));
+        // Filter deleting instances
+        this.instances = Object.assign({}, ...instances.filter(i => i.status !== 3).map(i => ({[i.taleId]: i})));
       });
     }, (err: any) => {
       this.logger.error("Failed to GET /instance:", err);

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, NgZone, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
@@ -14,7 +14,7 @@ import { CopyOnLaunchModalComponent } from '@tales/components/modals/copy-on-lau
   templateUrl: './tale-run-button.component.html',
   styleUrls: ['./tale-run-button.component.scss']
 })
-export class TaleRunButtonComponent {
+export class TaleRunButtonComponent implements OnChanges {
   @Input() instance: Instance;
   @Input() tale: Tale;
 
@@ -22,15 +22,68 @@ export class TaleRunButtonComponent {
 
   interval: any;
 
-  @Output() readonly taleInstanceStateChanged = new EventEmitter<Tale>();
+  @Output() readonly taleInstanceStateChanged = new EventEmitter<{ tale: Tale; instance: Instance }>();
 
   constructor(
-    private readonly zone: NgZone,
+    private readonly ref: ChangeDetectorRef,
     private readonly dialog: MatDialog,
     private readonly logger: LogService,
     private readonly taleService: TaleService,
     private readonly instanceService: InstanceService
   ) {}
+
+  ngOnChanges(): void {
+    if (this.instance && (this.instance.status === 0 || this.instance.status === 3)) {
+      this.autoRefresh();
+    }
+  }
+
+  autoRefresh(): void {
+    const stopPolling = () => {
+      clearInterval(this.interval);
+      this.interval = undefined;
+      this.taleInstanceStateChanged.emit(this);
+      this.ref.detectChanges();
+    };
+
+    // this.zone.runOutsideAngular(() => {
+    if (this.interval) {
+      stopPolling();
+    }
+
+    this.interval = setInterval(() => {
+      if (!this.instance || !this.instance._id) {
+        stopPolling();
+        return;
+      }
+
+      this.instanceService.instanceGetInstance(this.instance._id).subscribe(
+        (watched: Instance) => {
+          this.logger.debug('Polling for instance status:', watched._id);
+          // this.refilter();
+
+          this.instance = watched;
+
+          // Once instance is running, stop the polling
+          if (watched.status === 1) {
+            this.instance = watched;
+            stopPolling();
+          }
+        },
+        err => {
+          if (err.error.message.startsWith('Invalid instance id')) {
+            this.instance = undefined;
+          } else {
+            this.logger.error('Error polling for instance status:', err);
+          }
+
+          // Stop the polling if an error is hit
+          stopPolling();
+        }
+      );
+    }, 2000);
+    // });
+  }
 
   startTale(): void {
     if (this.tale._accessLevel < 2) {
@@ -39,52 +92,19 @@ export class TaleRunButtonComponent {
       return;
     }
 
-    const stopPolling = () => {
-      clearInterval(this.interval);
-      this.interval = undefined;
-    };
-
     const params = { taleId: this.tale._id };
     this.instanceService.instanceCreateInstance(params).subscribe(
       (instance: Instance) => {
-        this.zone.run(() => {
-          this.logger.debug('Starting tale:', this.tale._id);
-          this.instance = instance;
-          this.taleInstanceStateChanged.emit(this.tale);
-          // this.refilter();
+        // this.zone.run(() => {
+        this.logger.debug('Starting tale:', this.tale._id);
+        this.instance = instance;
+        this.taleInstanceStateChanged.emit(this);
+        this.ref.detectChanges();
 
-          // Poll / wait for launch
-          // TODO: Fix edge cases (refresh, etc)
-          this.zone.runOutsideAngular(() => {
-            if (this.interval) {
-              stopPolling();
-            }
-
-            this.interval = setInterval(() => {
-              this.instanceService.instanceGetInstance(instance._id).subscribe(
-                (watched: Instance) => {
-                  this.logger.debug('Polling for instance status:', watched._id);
-                  // this.refilter();
-                  this.taleInstanceStateChanged.emit(this.tale);
-
-                  // Once instance is running, stop the polling
-                  if (watched.status === 1) {
-                    this.zone.run(() => {
-                      this.instance = watched;
-                      stopPolling();
-                    });
-                  }
-                },
-                err => {
-                  this.logger.error('Error polling for instance status:', err);
-
-                  // Stop the polling if an error is hit
-                  stopPolling();
-                }
-              );
-            }, 2000);
-          });
-        });
+        // Poll / wait for launch
+        // TODO: Fix edge cases (refresh, etc)
+        this.autoRefresh();
+        // });
       },
       (err: any) => {
         this.logger.error('Failed to create instance:', err);
@@ -101,19 +121,27 @@ export class TaleRunButtonComponent {
     }
 
     this.logger.debug('Stopping tale:', this.tale._id);
+
+    // Show a fake "Deleting" message for a few seconds
+    this.instance.status = 3;
+    this.taleInstanceStateChanged.emit(this);
+    this.ref.detectChanges();
+
     this.instanceService
       .instanceDeleteInstance(instance._id)
-      .pipe(enterZone(this.zone))
+      // .pipe(enterZone(this.zone))
       .subscribe(
         (deleted: Instance) => {
           this.logger.debug('Instance deleted:', deleted);
           // this.zone.run(() => {
-          this.instance = undefined;
-          this.taleInstanceStateChanged.emit(this.tale);
+
+          // Clear the fake "Deleting" message
+          this.autoRefresh();
           // });
         },
         err => {
           this.logger.error('Failed to delete instance:', err);
+          this.autoRefresh();
         }
       );
   }


### PR DESCRIPTION
## Problem
Tale "popout" icon is missing from Run view. Previous dashboard had a button allowing the user to "popout" the iframe into a new tab.

Fixes #46 
Fixes #44 
  
NOTE: The "Stop Tale" button properly shows that the Tale is stopping, but the Run > Interact view does not appear to update correctly

## Approach
* Added the popout button to the tab bar of the Run view
* Improved the status/progress indicators on the Run > Interact view

## How to Test
Prerequisites: at least one Tale created and (ideally) running

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Choose a running Tale and click "View"
    * You should be brought to the Run > Metadata view
4. Click the "Interact" tab and then click "Run Tale" at the top-right
    * You should see the Tale begin to start
5. Wait for the Tale to finish starting up
    * You should see a blue popout icon on the top-right of the tab bar once the container has started (e.g. when the InstanceStatus is `RUNNING == 1`)
6. Click the popout button
    * You should see a new tab open displaying only the contents within the iframe
