### PR TITLE
Fix category and title display in Tale Catalog view

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -53,7 +53,7 @@
             </div>
             <div class="content">
               <div style="text-transform: uppercase; color: #ba975e;font-weight: 700;">
-                {{ tale.categories }}
+                {{ tale.category }}
               </div>
               <div class="t-title">
                 <h3 [title]="tale.title">
@@ -129,7 +129,7 @@
 
           <div class="content">
             <div style="text-transform: uppercase; color: #ba975e;font-weight: 700;">
-                {{ tale.categories }}
+                {{ tale.category }}
             </div>
             <div class="t-title">
                 <h3 [title]="tale.title">

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
@@ -53,7 +53,7 @@
             </div>
             <div class="content">
               <div style="text-transform: uppercase; color: #ba975e;font-weight: 700;">
-                {{ tale.categories }}
+                {{ tale.category }}
               </div>
               <div class="t-title">
 
@@ -119,7 +119,7 @@
           </div>
           <div class="content">
             <div style="text-transform: uppercase; color: #ba975e;font-weight: 700;">
-                {{ tale.categories }}
+                {{ tale.category }}
             </div>
             <div class="t-title">
               <h3 [title]="tale.title">

--- a/src/assets/sass/wholetale-dashboard.scss
+++ b/src/assets/sass/wholetale-dashboard.scss
@@ -535,7 +535,7 @@ p.status span {
 }
 
 .card .t-title {
-  height: 5.5em;
+  //height: 5.5em;
   overflow: hidden;
   position: relative;
   margin-bottom: 10px;


### PR DESCRIPTION
## Problem
Category does not display at all when browsing the Tale Catalog.

<img width="276" alt="tale-catalog-missing-category-white-box" src="https://user-images.githubusercontent.com/1413653/84834740-bbc11e80-aff7-11ea-9c85-67e851f27f7b.png">

Additionally, a noticeable small white box appears over the top of the Tale title, in the case that it is too long and needs to be truncated.

## Approach
* Fix `tale.categories` to `tale.category` on the Catalog view(s)
* Remove the arbitrary `height` applied to `t-title` to fix the truncation fade/gradient

## How to Test
Prerequisites: at least one Tale created with a very long title (e.g. `Fire influences on forest recovery and associated climate feedbacks in Siberian Larch Forests, Russia`)

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog
    * You should see the `tale.category` now appears in a yellowish font above each Tale's title
    * NOTE: For LIGO Tale, this should read `ASTRONOMY`
4. Scroll to a Tale with a very long name
    * You should see that the truncation gradient now appears more smoothly

<img width="276" alt="Screen Shot 2020-06-16 at 5 35 56 PM" src="https://user-images.githubusercontent.com/1413653/84834859-f4f98e80-aff7-11ea-9185-d3684d774593.png">

