### PR TITLE
fix: handle 'too many instances' error

### DIFF
--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -7,7 +7,7 @@ import { InstanceService } from '@api/services/instance.service';
 import { TaleService } from '@api/services/tale.service';
 import { LogService } from '@framework/core/log.service';
 import { enterZone } from '@framework/ngrx/enter-zone.operator';
-import { ErrorModalComponent } from '@shared/error-modal/error-modal.component';
+import { ErrorModalComponent } from '@shared/error-handler/error-modal/error-modal.component';
 import { CopyOnLaunchModalComponent } from '@tales/components/modals/copy-on-launch-modal/copy-on-launch-modal.component';
 
 @Component({
@@ -80,6 +80,7 @@ export class TaleRunButtonComponent {
                 },
                 err => {
                   this.logger.error('Error polling for instance status:', err);
+                  this.dialog.open(ErrorModalComponent, { data: { error: err.error } });
 
                   // Stop the polling if an error is hit
                   stopPolling();
@@ -91,6 +92,7 @@ export class TaleRunButtonComponent {
       },
       (err: any) => {
         this.logger.error('Failed to create instance:', err);
+        this.dialog.open(ErrorModalComponent, { data: { error: err.error } });
       }
     );
   }


### PR DESCRIPTION
## Problem
When launching a third Tale, there should be a message displayed informing the user that they have reached the limit for running Tale instances. This modal does not display, and the error is simply sent to the developer console.

Fixes #52 
  
## Approach
Use the generic `ErrorModalComponent` to display the error modal as intended.

## How to Test
Prerequisites: 2 Tales already running

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog view
4. Launch 2 Tales, if you haven't already
5. Choose a Tale that is not running and click "Run Tale"
    * You should see an error-modal appear, displaying the error message encountered: `You have reached a limit for running instances (2). Please shutdown one of the running instances before continuing.`
6. Click "View" on a Tale that is not running
7. At the top-right, click "Run Tale"
    * You should see an error-modal appear, displaying the error message encountered: `You have reached a limit for running instances (2). Please shutdown one of the running instances before continuing.`