### PR TITLE
Run view should show COPY/PUBLIC/PRIVATE tags

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -1,10 +1,10 @@
 <div fxFlex fxLayout="row" fxLayoutAlign="space-between stretch" [@routeAnimation]>
     <div class="ui stretched stackable grid panel-container">
-        <div class="row" style="padding-top:20px">
+        <div class="row">
             <div class="sixteen wide column">
 
                 <div class="ui breadcrumb">
-                    <a routerLink="/" routerLinkActive="active" class="section">
+                    <a routerLink="/" class="section">
                       <i class="left angle icon"></i>
                       Return to Dashboard
                     </a>
@@ -16,23 +16,28 @@
                             <div class="ui stackable grid">
                                 <div class="ten wide column">
                                     <div class="title-info">
-                                        <img [src]="tale.illustration" *ngIf="tale.illustration">
+                                        <div class="img-holder">
+                                            <img [src]="tale.illustration" *ngIf="tale.illustration">
+                                        </div>
                                         <img [src]="tale.icon" class="env" *ngIf="tale.icon">
-                                        <p>{{ tale.title | truncate:100 }}</p>
-
-                                        <p class="qualifier">
+                                        <div class="title">{{ tale.title | truncate:100 }}</div>
+                                        <div class="author">
                                             <span *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorOrcid">
                                                 <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>
                                             </span>
                                             <span *ngIf="!tale.authors.length && creator">{{ creator.firstName }} {{ creator.lastName }}</span>
                                             <span *ngIf="!tale.authors.length && !creator">???</span>
-                                        </p>
+                                        </div>
+                                        <div class="title-tags">
+                                            <span class="ui horizontal label wt-green" *ngIf="tale.copyOfTale">COPY</span>
+                                            <span class="ui horizontal label wt-green">{{ tale.public ? 'PUBLIC' : 'PRIVATE'}}</span>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="six wide column" style="text-align: right">
                                     <app-tale-run-button class="tale-run-button" [tale]="tale" [instance]="instance" isPrimary="true" (taleInstanceStateChanged)="taleInstanceStateChanged($event)"></app-tale-run-button>
                                     <a routerLink="/" routerLinkActive="active" class="ui button" style="margin-right: 10px">
-                                      Close
+                                        Close
                                     </a>
 
 

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -12,6 +12,10 @@
   }
 }
 
+.ui.breadcrumb a {
+  color: #333;
+}
+
 .panel-container {
   width: 100%;
 }
@@ -19,4 +23,200 @@
 .tale-run-button {
   display: inline-block;
   margin-right: 10px;
+}
+
+.wt-panel {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  -webkit-border-radius: 1rem;
+  -moz-border-radius: 1rem;
+  border-radius: 1rem;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.075);
+  padding: 0;
+  height: 100%;
+}
+
+.wt-panel .wt-panel-header {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  padding: 0.8rem 1.6rem;
+  letter-spacing: 0.02rem;
+  background: #fff;
+  -webkit-border-top-left-radius: 1rem;
+  -moz-border-top-left-radius: 1rem;
+  border-top-left-radius: 1rem;
+  -webkit-border-top-right-radius: 1rem;
+  -moz-border-top-right-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+
+.wt-panel .title-info img.env {
+  width: 2.5rem;
+  position: absolute;
+  top: -0.5rem;
+  left: -0.5rem;
+  background: white;
+  border-radius: 20px;
+}
+
+.wt-panel .wt-panel-header img {
+  height: 2.25rem;
+  margin: 0 0.75rem 0 0;
+  float: left;
+}
+.wt-panel .tale-info {
+  padding: 1em 0 0;
+}
+
+.wt-panel .title-info,
+.wt-panel .action-info {
+  position: relative;
+  padding-left: 4rem;
+}
+
+.wt-panel .title-info .label {
+  font-size: 0.65rem;
+}
+
+.wt-green {
+  background-color: #8bc44a !important;
+  border-color: #8bc44a !important;
+  color: #fff !important;
+}
+
+.wt-panel .title-info .title-tags {
+  margin-top: -0.3rem;
+}
+
+.wt-panel .title-info .title {
+  font-size: 1.2em;
+  line-height: 1.2;
+  font-weight: 600;
+  margin: 0;
+  max-width: 75%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+}
+
+.wt-panel .title-info .author {
+  font-size: 1em;
+  line-height: 1.2;
+  font-weight: 400;
+  font-style: italic;
+  margin: 0 0 0 6px;
+  max-width: 25%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+}
+
+.wt-panel.bg-grey {
+  background: #f9fafb;
+}
+.wt-panel:nth-child(2) {
+  margin-top: 1rem;
+}
+
+.wt-panel .wt-panel-body {
+  padding: 1.5rem 2rem 3rem;
+}
+.wt-panel .wt-panel-body.bg-grey,
+.wt-panel .wt-panel-header.bg-grey {
+  background-color: #f9fafb;
+}
+
+.wt-panel-body .ui.input {
+  width: 100%;
+}
+
+.wt-panel .wt-panel-header.tabs {
+  border: none;
+  padding: 0;
+  letter-spacing: 0;
+}
+
+.wt-panel .wt-panel-header.tabs .ui.menu {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  border: none;
+  -webkit-border-top-left-radius: 1rem;
+  -moz-border-top-left-radius: 1rem;
+  border-top-left-radius: 1rem;
+  -webkit-border-top-right-radius: 1rem;
+  -moz-border-top-right-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+.wt-panel .wt-panel-header.tabs .ui.menu > .item:first-child {
+  -webkit-border-top-left-radius: 1rem;
+  -moz-border-top-left-radius: 1rem;
+  border-top-left-radius: 1rem;
+}
+.wt-panel .wt-panel-header.tabs .ui.menu > .item:last-child {
+  -webkit-border-top-right-radius: 1rem;
+  -moz-border-top-right-radius: 1rem;
+  border-top-right-radius: 1rem;
+}
+.wt-panel .wt-panel-header.tabs .ui.menu > .item {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+  font-size: 1.2rem;
+}
+.wt-panel .wt-panel-header.tabs .ui.menu > .item.active {
+  border-bottom: transparent;
+  font-weight: 600;
+}
+
+.wt-panel .tale-info {
+  padding: 1em 0 0;
+}
+.wt-panel .title-info,
+.wt-panel .action-info {
+  position: relative;
+  padding-left: 4rem;
+}
+.wt-panel .title-info img {
+  width: 3rem;
+  margin-right: 0.5rem;
+  position: absolute;
+  top: -0.25rem;
+  left: 0rem;
+}
+.wt-panel .action-info img {
+  width: 3rem;
+  height: auto;
+  margin-right: 0.5rem;
+  position: absolute;
+  top: -0.25rem;
+  left: 0rem;
+}
+.wt-panel .title-info img.env {
+  width: 2.5rem;
+  position: absolute;
+  top: -0.75rem;
+  left: -0.5rem;
+}
+.wt-panel .title-info p {
+  font-size: 1.2rem;
+  line-height: 1.2;
+  font-weight: 600;
+  margin: 0 1.5rem 0.2rem 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wt-panel .action-info p {
+  font-size: 1.2rem;
+  line-height: 1.2;
+  font-weight: 600;
+  margin: 0 1.5rem 0.2rem 0;
+}
+.wt-panel .title-info p.qualifier,
+.wt-panel .action-info p.qualifier {
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: italic;
+}
+
+.wt-panel .actions {
 }

--- a/src/app/tales/components/modals/copy-on-launch-modal/copy-on-launch-modal.component.html
+++ b/src/app/tales/components/modals/copy-on-launch-modal/copy-on-launch-modal.component.html
@@ -2,7 +2,7 @@
 
 <mat-dialog-content>
   <p>You do not have write access to this Tale.</p>
-  <p>Would you like to run a writeable copy of this Tale instead?</p>
+  <p>Would you like to create a writeable copy of this Tale that you can run instead?</p>
 </mat-dialog-content>
 
 <mat-dialog-actions>

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -162,7 +162,7 @@ export class TaleRunButtonComponent implements OnChanges {
           // this.refresh();
           // this.startTale(taleCopy);
           // Update the display with the newly-created Tale copy
-          this.taleInstanceStateChanged.emit(taleCopy);
+          this.taleInstanceStateChanged.emit({ tale: taleCopy, instance: null });
 
           // Navigate the UI to the new Tale copy
           this.router.navigate(['run', taleCopy._id]);

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -129,11 +129,15 @@ export class TaleRunButtonComponent {
       }
 
       this.taleService.taleCopyTale(this.tale._id).subscribe(
-        taleCopy => {
+        (taleCopy: Tale) => {
           this.logger.debug('Successfully copied Tale... now launching!', taleCopy);
           // this.refresh();
           // this.startTale(taleCopy);
+          // Update the display with the newly-created Tale copy
           this.taleInstanceStateChanged.emit(taleCopy);
+
+          // Navigate the UI to the new Tale copy
+          this.router.navigate(['run', taleCopy._id]);
         },
         err => {
           this.logger.error('Failed to copy Tale:', err);

--- a/src/assets/sass/style.scss
+++ b/src/assets/sass/style.scss
@@ -18,7 +18,7 @@ body {
   background: c(grey, gallery);
 }
 
-@import './wholetale-dashboard';
+@import './theme';
 
 .clickable {
   cursor: pointer;

--- a/src/assets/sass/theme.scss
+++ b/src/assets/sass/theme.scss
@@ -1,3 +1,5 @@
+$font-size: 1em;
+
 /*
  * WholeTale Dashboard - Semantic UI
  */
@@ -6,6 +8,7 @@
 
 html,
 body {
+  font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 
 body {
@@ -228,113 +231,6 @@ hr.env-separator {
   padding-right: 0.5rem;
 }
 
-.wt-panel {
-  background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-border-radius: 1rem;
-  -moz-border-radius: 1rem;
-  border-radius: 1rem;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.075);
-  padding: 0;
-  height: 100%;
-}
-.wt-panel.bg-grey {
-  background: #f9fafb;
-}
-.wt-panel:nth-child(2) {
-  margin-top: 1rem;
-}
-
-.wt-panel .wt-panel-header {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-  padding: 0.8rem 1.6rem;
-  letter-spacing: 0.02rem;
-  background: #fff;
-  -webkit-border-top-left-radius: 1rem;
-  -moz-border-top-left-radius: 1rem;
-  border-top-left-radius: 1rem;
-  -webkit-border-top-right-radius: 1rem;
-  -moz-border-top-right-radius: 1rem;
-  border-top-right-radius: 1rem;
-}
-.wt-panel .wt-panel-header img {
-  height: 2.25rem;
-  margin: 0 0.75rem 0 0;
-  float: left;
-}
-.wt-panel .wt-panel-header span {
-  font-size: 1.3rem;
-  color: rgba(0, 0, 0, 0.75);
-  font-weight: 300;
-  font-style: italic;
-  letter-spacing: 0.05rem;
-  padding-left: 0.4rem;
-}
-.wt-panel .wt-panel-header span.quota {
-  color: rgba(0, 0, 0, 0.75);
-  float: right;
-  position: relative;
-  font-size: 1rem;
-}
-.wt-panel .wt-panel-header i {
-  padding-right: 0.75rem;
-}
-.wt-panel .wt-panel-header i.right {
-  color: rgba(0, 0, 0, 0.6);
-  float: right;
-  position: relative;
-  padding-right: 0;
-  padding-top: 0.35rem;
-}
-
-.wt-panel .wt-panel-body {
-  padding: 1.5rem 2rem 3rem;
-}
-.wt-panel .wt-panel-body.bg-grey,
-.wt-panel .wt-panel-header.bg-grey {
-  background-color: #f9fafb;
-}
-
-.wt-panel-body .ui.input {
-  width: 100%;
-}
-
-.wt-panel .wt-panel-header.tabs {
-  border: none;
-  padding: 0;
-  letter-spacing: 0;
-}
-
-.wt-panel .wt-panel-header.tabs .ui.menu {
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  border: none;
-  -webkit-border-top-left-radius: 1rem;
-  -moz-border-top-left-radius: 1rem;
-  border-top-left-radius: 1rem;
-  -webkit-border-top-right-radius: 1rem;
-  -moz-border-top-right-radius: 1rem;
-  border-top-right-radius: 1rem;
-}
-.wt-panel .wt-panel-header.tabs .ui.menu > .item:first-child {
-  -webkit-border-top-left-radius: 1rem;
-  -moz-border-top-left-radius: 1rem;
-  border-top-left-radius: 1rem;
-}
-.wt-panel .wt-panel-header.tabs .ui.menu > .item:last-child {
-  -webkit-border-top-right-radius: 1rem;
-  -moz-border-top-right-radius: 1rem;
-  border-top-right-radius: 1rem;
-}
-.wt-panel .wt-panel-header.tabs .ui.menu > .item {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
-  font-size: 1.2rem;
-}
-.wt-panel .wt-panel-header.tabs .ui.menu > .item.active {
-  border-bottom: transparent;
-  font-weight: 600;
-}
-
 .placeholder-message {
   text-align: center;
   padding: 40% 0 40%;
@@ -353,60 +249,6 @@ hr.env-separator {
   font-size: 2.2rem;
   letter-spacing: 0.05rem;
   line-height: 1.3;
-}
-
-.wt-panel .tale-info {
-  padding: 1em 0 0;
-}
-.wt-panel .title-info,
-.wt-panel .action-info {
-  position: relative;
-  padding-left: 4rem;
-}
-.wt-panel .title-info img {
-  width: 3rem;
-  margin-right: 0.5rem;
-  position: absolute;
-  top: -0.25rem;
-  left: 0rem;
-}
-.wt-panel .action-info img {
-  width: 3rem;
-  height: auto;
-  margin-right: 0.5rem;
-  position: absolute;
-  top: -0.25rem;
-  left: 0rem;
-}
-.wt-panel .title-info img.env {
-  width: 2.5rem;
-  position: absolute;
-  top: -0.75rem;
-  left: -0.5rem;
-}
-.wt-panel .title-info p {
-  font-size: 1.2rem;
-  line-height: 1.2;
-  font-weight: 600;
-  margin: 0 1.5rem 0.2rem 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.wt-panel .action-info p {
-  font-size: 1.2rem;
-  line-height: 1.2;
-  font-weight: 600;
-  margin: 0 1.5rem 0.2rem 0;
-}
-.wt-panel .title-info p.qualifier,
-.wt-panel .action-info p.qualifier {
-  font-size: 1rem;
-  font-weight: 400;
-  font-style: italic;
-}
-
-.wt-panel .actions {
 }
 
 /* New Environment form */


### PR DESCRIPTION
## Problem
1. On creating a Tale copy, user is not brought to the new Tale's Run view
2. Fixes #27 - `copy-on-launch-modal` appears to indicate that it will *run* the Tale, when it does not
3. Fixes #26  - There is no indication that a particular Tale was copied from another Tale.

## Approach
Per the [mockups](https://whole-tale.github.io/wholetale-css-mockup/src/run.html):
1. Navigate the user to the new Tale when creating a copy, as we currently do for Create or Launch
2. Adjusted the text on the `copy-on-launch-modal` to better indicate that this operation will not actually Run the Tale
3. Added a `COPY` tag to the header of the Run view, also added the missing `PUBLIC` / `PRIVATE` indicators as well

## How to Test
Prerequisites: LIGO Tale

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Public Tales Catalog
4. Find the LIGO Tale and choose "Run Tale"
    * You should be prompted to create a copy
    * You should notice that this modal has had its text updated to say "create a writeable copy" instead of "run a writeable copy"
5. Confirm to create a copy
    * You should automatically be navigated to your new Tale copy's Run view
    * You should see the Run view's header has had some font/styling adjustments, and should more closely match the mockups
    * You should see that the author(s) now appears to the right of the Tale title
    * You should see the `COPY` and `PRIVATE` tags below your Tale's title
