### PR TITLE
Fix involatile download links on Run > Metadata view

### DIFF
--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -133,7 +133,9 @@
               <b>Involatile Data:</b>
               <span *ngIf="!tale.dataSet.length">No citable data</span>
               <ul *ngIf="tale.dataSet.length">
-                <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById"><a [href]="dataset.doi">{{ dataset.mountPath }}</a></li>
+                <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
+                    <a [href]="apiRoot + '/item/' + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
+                </li>
               </ul>
             </div>
             <div class="item">

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -134,7 +134,7 @@
               <span *ngIf="!tale.dataSet.length">No citable data</span>
               <ul *ngIf="tale.dataSet.length">
                 <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
-                    <a [href]="apiRoot + '/item/' + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
+                    <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
                 </li>
               </ul>
             </div>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectorRef, Component, Input, NgZone, OnInit } from '@angular/core';
+import { ApiConfiguration } from '@api/api-configuration';
 import { Image } from '@api/models/image';
 import { License } from '@api/models/license';
 import { Tale } from '@api/models/tale';
@@ -30,17 +31,21 @@ export class TaleMetadataComponent implements OnInit {
   environment: Image;
   newAuthor: TaleAuthor;
 
+  apiRoot: string;
+
   // Edit mode
   _previousState: Tale;
   editing = false;
 
   constructor(private ref: ChangeDetectorRef,
               private zone: NgZone,
+              private config: ApiConfiguration,
               private logger: LogService,
               private taleService: TaleService,
               private licenseService: LicenseService,
               private notificationService: NotificationService,
               private imageService: ImageService) {
+    this.apiRoot = this.config.rootUrl;
     this.resetNewAuthor();
   }
 


### PR DESCRIPTION
## Problem
Download links under `Involatile Data` are invalid, and contain `null`

Fixes #23 

## Approach
Fix the broken links to use the same API call as the legacy dashboard.

NOTE: Girder's `item/:id/download` link returns a 303 redirect to the file's original location. This can break for particular types of files that the browser can display, which do not appear to be downloaded by default. For example, the `BBH_events_v3.json` from the `LIGO Tutorial` Tale. I believe that sending the `contentDisposition=attached` parameter is supposed to tell Girder to download the item instead of redirecting to it, but I don't think that this parameter is currently being respected in all cases.

## How to Test
Prerequisites: LIGO Tutorial Tale

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Run > Metadata view for the LIGO tale
4. Scroll down to the *Involatile Data* section
5. Click a few links
    * The `.hd5` files should download as expected
    * NOTE: `BBH_events_v3.json` does not download and simply redirects to the file. This was apparently also true in the legacy dashboard, but was never noticed