### PR TITLE
Fix: add/style missing info on metadata

### DIFF
--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -3,7 +3,7 @@
     <div class="sixteen wide column">
 
       <!-- Edit Mode (read/write for) -->
-      <div id="taleMetadataForm" class="ui form" *ngIf="editing">
+      <div id="taleMetadataForm" class="ui form" *ngIf="tale._accessLevel > 1">
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Title</label>
@@ -25,10 +25,10 @@
                   <th>ORCID</th>
                   <th></th>
                 </tr>
-                <tr *ngFor="let author of tale.authors">
-                  <td><input type="text" name="firstName" placeholder="Enter first name" [(ngModel)]="author.firstName" required></td>
-                  <td><input type="text" name="lastName" placeholder="Enter last name" [(ngModel)]="author.lastName" required></td>
-                  <td><input type="text" name="orcid" placeholder="Enter ORCID" [(ngModel)]="author.orcid" required></td>
+                <tr *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorHash">
+                  <td><input type="text" name="firstName_{{i}}" placeholder="Enter first name" [(ngModel)]="author.firstName" required></td>
+                  <td><input type="text" name="lastName_{{i}}" placeholder="Enter last name" [(ngModel)]="author.lastName" required></td>
+                  <td><input type="text" name="orcid_{{i}}" placeholder="Enter ORCID" [(ngModel)]="author.orcid" required></td>
                   <td><button class="ui tiny negative button" (click)="removeAuthor(author)"><i class="fas fa-trash"></i></button></td>
                 </tr>
               </table>
@@ -138,11 +138,18 @@
           <div class="field two wide right aligned column">
             <button class="ui blue submit button" (click)="updateTale()">Save</button>
           </div>
+
+          <div class="field toggle ui checkbox four wide column">
+            <input type="checkbox" name="public"
+                [checked]="tale.public"
+                (change)="tale.public=!tale.public">
+            <label>Public?</label>
+          </div>
         </div>
       </div>
 
       <!-- View Mode (read-only) -->
-      <div class="ui grid" *ngIf="!editing">
+      <div class="ui grid" *ngIf="tale._accessLevel <= 1">
         <div class="ten wide column">
           <div class="ui list">
             <div class="item">

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -95,7 +95,7 @@
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Description</label>
-          <div class="thirteen wide column">
+          <div class="thirteen wide column" style="padding-left:0;">
             <div class="ui top attached tabular menu">
               <a class="item" [ngClass]="{ 'active': !previewMarkdown }" (click)="previewMarkdown=false">
                 <i class="icon code"></i>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -2,162 +2,22 @@
   <div class="row">
     <div class="sixteen wide column">
 
-      <!-- Edit Mode (read/write) -->
+      <!-- Edit Mode (read/write for) -->
       <div id="taleMetadataForm" class="ui form" *ngIf="editing">
 
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Title</label>
-                <div class="field thirteen wide column">
-                  <input placeholder="Enter a title..." type="text" [(ngModel)]="tale.title">
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Authors</label>
-                <div class="thirteen wide column">
-                  <h4 style="text-align: center">Created by <span style="color:#67c096">{{creator.firstName}} {{creator.lastName}}</span></h4>
-
-                  <form class="ui form" *ngIf="tale.authors.length">
-                    <table class="ui table striped condensed">
-                      <tr>
-                        <th>First Name</th>
-                        <th>Last Name</th>
-                        <th>ORCID</th>
-                        <th></th>
-                      </tr>
-                      <tr *ngFor="let author of tale.authors">
-                        <td><input type="text" name="firstName" placeholder="Enter first name" [(ngModel)]="author.firstName" required></td>
-                        <td><input type="text" name="lastName" placeholder="Enter last name" [(ngModel)]="author.lastName" required></td>
-                        <td><input type="text" name="orcid" placeholder="Enter ORCID" [(ngModel)]="author.orcid" required></td>
-                        <td><button class="ui tiny negative button" (click)="removeAuthor(author)"><i class="fas fa-trash"></i></button></td>
-                      </tr>
-                    </table>
-                  </form>
-                  <a style="cursor:pointer;" (click)="addNewAuthor()"><i class="fas fa-plus add-author-icon"></i> Add an author</a>
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Category</label>
-                <div class="field thirteen wide column">
-                  <input placeholder="Choose a category..." type="text" [(ngModel)]="tale.category">
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Environment</label>
-                <div class="field thirteen wide column">
-                    <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="tale.imageId" required>
-                        <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
-                        <img class="ui avatar image" [src]="env.icon | safe:'url'" />
-                        {{ env.name }}
-                        </option>
-                    </select>
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Datasets used</label>
-                <span *ngIf="!tale.dataSetCitation">No citable data</span>
-                <ul *ngIf="tale.dataSetCitation" style="max-width:60vw">
-                    <li *ngFor="let citation of tale.dataSetCitation">
-                        <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
-                            {{ citation }}
-                        </a>
-                    </li>
-                </ul>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">License</label>
-                <div class="field thirteen wide column">
-                    <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX" required>
-                        <option class="item" [ngValue]="license.spdx" *ngFor="let license of (licenses | async); index as i; trackBy: trackBySpdx">
-                        {{ license.name }}
-                        </option>
-                    </select>
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Date created</label>
-                <div class="field thirteen wide column">
-                  <span>{{ tale.created | date:'full' }}</span>
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Last updated</label>
-                <div class="field thirteen wide column">
-                  <span>{{ tale.updated | date:'full' }}</span>
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Description</label>
-                <div class="thirteen wide column">
-                  <div class="ui top attached tabular menu">
-                    <a class="item" [ngClass]="{ 'active': !previewMarkdown }" (click)="previewMarkdown=false">
-                      <i class="icon code"></i>
-                      Edit
-                    </a>
-                    <a class="item" [ngClass]="{ 'active': previewMarkdown }" (click)="previewMarkdown=true">
-                      <i class="icon unhide"></i>
-                      Preview
-                    </a>
-                  </div>
-                  <div class="ui bottom attached tab segment" [ngClass]="{ 'active': !previewMarkdown }">
-                    <textarea rows="5" type="text" name="description" placeholder="Description is required." [(ngModel)]="tale.description" required></textarea>
-                  </div>
-                  <div class="ui bottom attached tab segment" [ngClass]="{ 'active': previewMarkdown }">
-                    <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
-                  </div>
-                </div>
-              </div>
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Illustration</label>
-                <div class="ui action field thirteen wide column">
-                  <input placeholder="http://" type="text" [(ngModel)]="tale.illustration">
-                  <div class="or"></div>
-                  <button class="ui blue button" (click)="generateIcon()">Generate Illustration</button>
-                </div>
-              </div>
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned">Published location</label>
-                <div class="field thirteen wide column">
-                  <span *ngIf="!tale.publishInfo || !tale.publishInfo.length">This Tale has not been published</span>
-                  <span *ngIf="tale.publishInfo && tale.publishInfo.length">{{ tale.publishInfo[0].uri }}</span>
-                </div>
-              </div>
-
-              <div class="inline fields ui grid">
-                <label class="two wide column right aligned"></label>
-                <div class="field two wide right aligned column">
-                  <button class="ui blue submit button" (click)="updateTale()">Save</button>
-                </div>
-              </div>
-
-
-            </div>
-      <!-- <form class="ui form" *ngIf="editing">
-        <div class="field">
-          <label>Category</label>
-          <input type="text" name="category" placeholder="Category is required." [(ngModel)]="tale.category" required>
-        </div>
-        <div class="field">
-          <label>Title</label>
-          <input type="text" name="title" placeholder="Title is required." [(ngModel)]="tale.title" required>
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Title</label>
+          <div class="field thirteen wide column">
+            <input placeholder="Enter a title..." type="text" [(ngModel)]="tale.title">
+          </div>
         </div>
 
-        <div class="item" *ngIf="creator" style="margin-bottom:7px;">
-          <b>Created By:</b>
-          {{ creator.firstName }} {{ creator.lastName }}
-        </div>
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Authors</label>
+          <div class="thirteen wide column" style="padding-left:0;">
+            <h4 style="text-align: center">Created by <span style="color:#67c096">{{creator.firstName}} {{creator.lastName}}</span></h4>
 
-        <div class="fields">
-          <div class="field">
-            <label>Authors</label>
-            <form class="ui form">
+            <form class="ui form" *ngIf="tale.authors.length">
               <table class="ui table striped condensed">
                 <tr>
                   <th>First Name</th>
@@ -166,162 +26,197 @@
                   <th></th>
                 </tr>
                 <tr *ngFor="let author of tale.authors">
-                  <td>{{ author.firstName }}</td>
-                  <td>{{ author.lastName }}</td>
-                  <td>{{ author.orcid }}</td>
+                  <td><input type="text" name="firstName" placeholder="Enter first name" [(ngModel)]="author.firstName" required></td>
+                  <td><input type="text" name="lastName" placeholder="Enter last name" [(ngModel)]="author.lastName" required></td>
+                  <td><input type="text" name="orcid" placeholder="Enter ORCID" [(ngModel)]="author.orcid" required></td>
                   <td><button class="ui tiny negative button" (click)="removeAuthor(author)"><i class="fas fa-trash"></i></button></td>
-                </tr>
-                <tr>
-                  <td>
-                    <input type="text" name="firstName" placeholder="Enter first name" [(ngModel)]="newAuthor.firstName" required>
-                  </td>
-                  <td>
-                    <input type="text" name="lastName" placeholder="Enter last name" [(ngModel)]="newAuthor.lastName" required>
-                  </td>
-                  <td>
-                    <input type="text" name="orcid" placeholder="Enter ORCID" [(ngModel)]="newAuthor.orcid" required>
-                  </td>
-                  <td>
-                    <button class="ui tiny positive button" (click)="addAuthor(newAuthor)"
-                            [ngClass]="{ 'disabled': !newAuthor.firstName || !newAuthor.lastName || !newAuthor.orcid }"
-                            [disabled]="!newAuthor.firstName || !newAuthor.lastName || !newAuthor.orcid">
-                      <i class="fas fa-plus"></i>
-                    </button>
-                  </td>
                 </tr>
               </table>
             </form>
+            <a style="cursor:pointer;" (click)="addNewAuthor()"><i class="fas fa-plus add-author-icon"></i> Add an author</a>
           </div>
         </div>
-        <div class="field">
-          <label>Description</label>
-          <textarea *ngIf="!previewMarkdown" rows="5" type="text" name="description" placeholder="Description is required." [(ngModel)]="tale.description" required></textarea>
-          <markdown *ngIf="previewMarkdown" ngPreserveWhitespaces [data]="tale.description"></markdown>
-          <button class="ui right floated button" (click)="previewMarkdown=!previewMarkdown">
-            <i class="fas fa-pencil" *ngIf="previewMarkdown"></i>
-            <i class="fas fa-eye" *ngIf="!previewMarkdown"></i>
-            {{ previewMarkdown ? 'Edit' : 'Preview' }}
-          </button>
-        </div>
-        <div class="field">
-          <label>License</label>
-          <select class="ui floating labeled icon selection dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX" required>
-            <option class="item" [ngValue]="license.spdx" *ngFor="let license of (licenses | async); index as i; trackBy: trackBySpdx">
-              {{ license.name }}
-            </option>
-          </select>
-        </div>
-        <div class="field">
-          <label>Compute Environment</label>
-         <\!-- <div class="ui floating labeled icon dropdown button">
-            <i class="add user icon"></i>
-            <span class="text">Add User</span>
-            <div class="menu">
-              <div class="header">
-                Choose a Compute Environment...
-              </div>
-              <div class="item" *ngFor="let env of environments; index as i; trackBy: trackById">
-                <img class="ui avatar image" [src]="environment.logo">
-                {{ environment.name }}
-              </div>
-            </div>
-          </div> --\>
-          <select class="ui floating labeled icon selection dropdown" name="imageId" [(ngModel)]="tale.imageId" required>
-            <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
-              <img class="ui avatar image" [src]="env.icon | safe:'url'" />
-              {{ env.name }}
-            </option>
-          </select>
-        </div>
-      </form> -->
 
-      <!-- View Mode (read-only) -->
-      <div class="ui list" *ngIf="!editing">
-        <div class="item">
-          <b>Category:</b>
-          <span class="category">{{ tale.category }}</span>
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Category</label>
+          <div class="field thirteen wide column">
+            <input placeholder="Choose a category..." type="text" [(ngModel)]="tale.category">
+          </div>
         </div>
-        <div class="item">
-          <b>Title:</b>
-          {{ tale.title }}
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Environment</label>
+          <div class="field thirteen wide column">
+              <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="tale.imageId" required>
+                  <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
+                  <img class="ui avatar image" [src]="env.icon | safe:'url'" />
+                  {{ env.name }}
+                  </option>
+              </select>
+          </div>
         </div>
-        <div class="item" *ngIf="creator">
-          <b>Created By:</b>
-          {{ creator.firstName }} {{ creator.lastName }}
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Datasets used</label>
+          <span *ngIf="!tale.dataSetCitation">No citable data</span>
+          <ul *ngIf="tale.dataSetCitation" style="max-width:60vw">
+              <li *ngFor="let citation of tale.dataSetCitation">
+                  <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
+                      {{ citation }}
+                  </a>
+              </li>
+          </ul>
         </div>
-        <div class="item">
-          <b>Authors:</b>
-          <span *ngFor="let author of tale.authors; index as i; trackBy: trackById">
-              <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>
-          </span>
-          <span *ngIf="!tale.authors.length && creator">{{ creator.firstName }} {{ creator.lastName }}</span>
-          <span *ngIf="!tale.authors.length && !creator">???</span>
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">License</label>
+          <div class="field thirteen wide column">
+              <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX" required>
+                  <option class="item" [ngValue]="license.spdx" *ngFor="let license of (licenses | async); index as i; trackBy: trackBySpdx">
+                  {{ license.name }}
+                  </option>
+              </select>
+          </div>
         </div>
-        <div class="item">
-          <b>Description:</b>
-          <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Date created</label>
+          <div class="field thirteen wide column">
+            <span>{{ tale.created | date:'full' }}</span>
+          </div>
         </div>
-        <div class="item">
-          <b>License:</b>
-          {{ tale.licenseSPDX }}
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Last updated</label>
+          <div class="field thirteen wide column">
+            <span>{{ tale.updated | date:'full' }}</span>
+          </div>
         </div>
-        <div class="item">
-            <b>Published Location:</b>
-            <span *ngIf="tale.publishInfo && tale.publishInfo.length">{{ tale.publishInfo[0] }}</span>
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Description</label>
+          <div class="thirteen wide column">
+            <div class="ui top attached tabular menu">
+              <a class="item" [ngClass]="{ 'active': !previewMarkdown }" (click)="previewMarkdown=false">
+                <i class="icon code"></i>
+                Edit
+              </a>
+              <a class="item" [ngClass]="{ 'active': previewMarkdown }" (click)="previewMarkdown=true">
+                <i class="icon unhide"></i>
+                Preview
+              </a>
+            </div>
+            <div class="ui bottom attached tab segment" [ngClass]="{ 'active': !previewMarkdown }">
+              <textarea rows="5" type="text" name="description" placeholder="Description is required." [(ngModel)]="tale.description" required></textarea>
+            </div>
+            <div class="ui bottom attached tab segment" [ngClass]="{ 'active': previewMarkdown }">
+              <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+            </div>
+          </div>
+        </div>
+
+        <!-- TODO: "Generate" currently does nothing -->
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Illustration</label>
+          <div class="ui action field thirteen wide column">
+            <input placeholder="http://" type="text" [(ngModel)]="tale.illustration">
+            <div class="or"></div>
+            <button class="ui blue button" (click)="generateIcon()">Generate Illustration</button>
+          </div>
+        </div>
+
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned">Published location</label>
+          <div class="field thirteen wide column">
             <span *ngIf="!tale.publishInfo || !tale.publishInfo.length">This Tale has not been published</span>
+            <span *ngIf="tale.publishInfo && tale.publishInfo.length">{{ tale.publishInfo[0].uri }}</span>
+          </div>
         </div>
-        <div class="item spaced">
-          <b>Tale Specifics</b>
-          <div class="list">
-            <div class="item">
-              <b>Tale ID</b>
-              {{ tale._id }}
-            </div>
-            <div class="item">
-              <b>Involatile Data:</b>
-              <span *ngIf="!tale.dataSet.length">No citable data</span>
-              <ul *ngIf="tale.dataSet.length">
-                <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
-                    <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
-                </li>
-              </ul>
-            </div>
-            <div class="item">
-              <b>Environment:</b>
 
-              <img *ngIf="tale.icon" class="ui image" [src]="tale.icon | safe:'url'" style="height:1.5em; margin:0 .4em; display: inline-block">
-              <span *ngIf="(tale | taleImage | async) as environment">{{ environment.name }}</span>
-            </div>
-            <div class="item">
-              <b>Tale Created:</b>
-              {{ tale.created | date }}
-            </div>
-            <div class="item">
-              <b>Tale Updated:</b>
-              {{ tale.updated | date }}
-            </div>
+        <div class="inline fields ui grid">
+          <label class="two wide column right aligned"></label>
+          <div class="field two wide right aligned column">
+            <button class="ui blue submit button" (click)="updateTale()">Save</button>
           </div>
         </div>
       </div>
 
-    </div>
+      <!-- View Mode (read-only) -->
+      <div class="ui grid" *ngIf="!editing">
+        <div class="ten wide column">
+          <div class="ui list">
+            <div class="item">
+              <b>Category:</b>
+              <span class="category">{{ tale.category }}</span>
+            </div>
+            <div class="item">
+              <b>Title:</b>
+              {{ tale.title }}
+            </div>
+            <div class="item" *ngIf="creator">
+              <b>Created By:</b>
+              {{ creator.firstName }} {{ creator.lastName }}
+            </div>
+            <div class="item">
+              <b>Authors:</b>
+              <span *ngFor="let author of tale.authors; index as i; trackBy: trackById">
+                  <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>
+              </span>
+              <span *ngIf="!tale.authors.length && creator">{{ creator.firstName }} {{ creator.lastName }}</span>
+              <span *ngIf="!tale.authors.length && !creator">???</span>
+            </div>
+            <div class="item">
+              <b>Description:</b>
+              <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+            </div>
+            <div class="item">
+              <b>License:</b>
+              {{ tale.licenseSPDX }}
+            </div>
+            <div class="item">
+                <b>Published Location:</b>
+                <span *ngIf="tale.publishInfo && tale.publishInfo.length">{{ tale.publishInfo[0] }}</span>
+                <span *ngIf="!tale.publishInfo || !tale.publishInfo.length">This Tale has not been published</span>
+            </div>
+            <div class="item spaced">
+              <b>Tale Specifics</b>
+              <div class="list">
+                <div class="item">
+                  <b>Tale ID</b>
+                  {{ tale._id }}
+                </div>
+                <div class="item">
+                  <b>Involatile Data:</b>
+                  <span *ngIf="!tale.dataSet.length">No citable data</span>
+                  <ul *ngIf="tale.dataSet.length">
+                    <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
+                        <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
+                    </li>
+                  </ul>
+                </div>
+                <div class="item">
+                  <b>Environment:</b>
 
-    <div class="ui six wide column" *ngIf="!editing">
-      <img class="ui image img-responsive" [src]="tale.illustration | safe:'url'" *ngIf="tale.illustration">
+                  <img *ngIf="tale.icon" class="ui image" [src]="tale.icon | safe:'url'" style="height:1.5em; margin:0 .4em; display: inline-block">
+                  <span *ngIf="(tale | taleImage | async) as environment">{{ environment.name }}</span>
+                </div>
+                <div class="item">
+                  <b>Tale Created:</b>
+                  {{ tale.created | date }}
+                </div>
+                <div class="item">
+                  <b>Tale Updated:</b>
+                  {{ tale.updated | date }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="ui six wide column">
+          <img class="ui image img-responsive" [src]="tale.illustration | safe:'url'" *ngIf="tale.illustration">
+        </div>
+      </div>
     </div>
   </div>
-
-<!--div class="row" *ngIf="tale._accessLevel > 0">
-    <div class="ten wide column">
-      <button class="ui primary button" *ngIf="!editing" (click)="editTale()">
-        Edit
-      </button>
-      <button class="ui button" *ngIf="editing" (click)="cancelTaleEdit()">
-        Cancel
-      </button>
-      <button class="ui primary button" *ngIf="editing" (click)="saveTaleEdit()">
-        Save
-      </button>
-    </div>
-  </div-->
 </div>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -17,7 +17,7 @@
           <div class="thirteen wide column" style="padding-left:0;">
             <h4 style="text-align: center">Created by <span style="color:#67c096">{{creator.firstName}} {{creator.lastName}}</span></h4>
 
-            <form #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="tale.authors.length">
+            <form id="taleAuthorsSubForm" #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="tale.authors.length">
               <table class="ui table striped condensed">
                 <tr>
                   <th>First Name</th>
@@ -136,7 +136,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned"></label>
           <div class="field two wide right aligned column">
-            <button class="ui blue submit button" [disabled]="!taleMetadataForm.valid" (click)="updateTale()">Save</button>
+            <button class="ui blue submit button" [disabled]="!taleMetadataForm.valid || validateAuthors().length > 0" (click)="updateTale()">Save</button>
           </div>
 
           <div class="field toggle ui checkbox four wide column">

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -1,8 +1,145 @@
 <div class="ui stretched stackable grid" id="tale-metadata-container">
   <div class="row">
-    <div class="ui" [ngClass]="{ 'sixteen wide column': editing, 'ten wide column': !editing }">
+    <div class="sixteen wide column">
 
-      <form class="ui form" *ngIf="editing">
+      <!-- Edit Mode (read/write) -->
+      <div id="taleMetadataForm" class="ui form" *ngIf="editing">
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Title</label>
+                <div class="field thirteen wide column">
+                  <input placeholder="Enter a title..." type="text" [(ngModel)]="tale.title">
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Authors</label>
+                <div class="thirteen wide column">
+                  <h4 style="text-align: center">Created by <span style="color:#67c096">{{creator.firstName}} {{creator.lastName}}</span></h4>
+
+                  <form class="ui form" *ngIf="tale.authors.length">
+                    <table class="ui table striped condensed">
+                      <tr>
+                        <th>First Name</th>
+                        <th>Last Name</th>
+                        <th>ORCID</th>
+                        <th></th>
+                      </tr>
+                      <tr *ngFor="let author of tale.authors">
+                        <td><input type="text" name="firstName" placeholder="Enter first name" [(ngModel)]="author.firstName" required></td>
+                        <td><input type="text" name="lastName" placeholder="Enter last name" [(ngModel)]="author.lastName" required></td>
+                        <td><input type="text" name="orcid" placeholder="Enter ORCID" [(ngModel)]="author.orcid" required></td>
+                        <td><button class="ui tiny negative button" (click)="removeAuthor(author)"><i class="fas fa-trash"></i></button></td>
+                      </tr>
+                    </table>
+                  </form>
+                  <a style="cursor:pointer;" (click)="addNewAuthor()"><i class="fas fa-plus add-author-icon"></i> Add an author</a>
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Category</label>
+                <div class="field thirteen wide column">
+                  <input placeholder="Choose a category..." type="text" [(ngModel)]="tale.category">
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Environment</label>
+                <div class="field thirteen wide column">
+                    <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="tale.imageId" required>
+                        <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
+                        <img class="ui avatar image" [src]="env.icon | safe:'url'" />
+                        {{ env.name }}
+                        </option>
+                    </select>
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Datasets used</label>
+                <span *ngIf="!tale.dataSetCitation">No citable data</span>
+                <ul *ngIf="tale.dataSetCitation" style="max-width:60vw">
+                    <li *ngFor="let citation of tale.dataSetCitation">
+                        <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
+                            {{ citation }}
+                        </a>
+                    </li>
+                </ul>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">License</label>
+                <div class="field thirteen wide column">
+                    <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX" required>
+                        <option class="item" [ngValue]="license.spdx" *ngFor="let license of (licenses | async); index as i; trackBy: trackBySpdx">
+                        {{ license.name }}
+                        </option>
+                    </select>
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Date created</label>
+                <div class="field thirteen wide column">
+                  <span>{{ tale.created | date:'full' }}</span>
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Last updated</label>
+                <div class="field thirteen wide column">
+                  <span>{{ tale.updated | date:'full' }}</span>
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Description</label>
+                <div class="thirteen wide column">
+                  <div class="ui top attached tabular menu">
+                    <a class="item" [ngClass]="{ 'active': !previewMarkdown }" (click)="previewMarkdown=false">
+                      <i class="icon code"></i>
+                      Edit
+                    </a>
+                    <a class="item" [ngClass]="{ 'active': previewMarkdown }" (click)="previewMarkdown=true">
+                      <i class="icon unhide"></i>
+                      Preview
+                    </a>
+                  </div>
+                  <div class="ui bottom attached tab segment" [ngClass]="{ 'active': !previewMarkdown }">
+                    <textarea rows="5" type="text" name="description" placeholder="Description is required." [(ngModel)]="tale.description" required></textarea>
+                  </div>
+                  <div class="ui bottom attached tab segment" [ngClass]="{ 'active': previewMarkdown }">
+                    <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+                  </div>
+                </div>
+              </div>
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Illustration</label>
+                <div class="ui action field thirteen wide column">
+                  <input placeholder="http://" type="text" [(ngModel)]="tale.illustration">
+                  <div class="or"></div>
+                  <button class="ui blue button" (click)="generateIcon()">Generate Illustration</button>
+                </div>
+              </div>
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned">Published location</label>
+                <div class="field thirteen wide column">
+                  <span *ngIf="!tale.publishInfo || !tale.publishInfo.length">This Tale has not been published</span>
+                  <span *ngIf="tale.publishInfo && tale.publishInfo.length">{{ tale.publishInfo[0].uri }}</span>
+                </div>
+              </div>
+
+              <div class="inline fields ui grid">
+                <label class="two wide column right aligned"></label>
+                <div class="field two wide right aligned column">
+                  <button class="ui blue submit button" (click)="updateTale()">Save</button>
+                </div>
+              </div>
+
+
+            </div>
+      <!-- <form class="ui form" *ngIf="editing">
         <div class="field">
           <label>Category</label>
           <input type="text" name="category" placeholder="Category is required." [(ngModel)]="tale.category" required>
@@ -10,6 +147,11 @@
         <div class="field">
           <label>Title</label>
           <input type="text" name="title" placeholder="Title is required." [(ngModel)]="tale.title" required>
+        </div>
+
+        <div class="item" *ngIf="creator" style="margin-bottom:7px;">
+          <b>Created By:</b>
+          {{ creator.firstName }} {{ creator.lastName }}
         </div>
 
         <div class="fields">
@@ -71,7 +213,7 @@
         </div>
         <div class="field">
           <label>Compute Environment</label>
-         <!-- <div class="ui floating labeled icon dropdown button">
+         <\!-- <div class="ui floating labeled icon dropdown button">
             <i class="add user icon"></i>
             <span class="text">Add User</span>
             <div class="menu">
@@ -83,7 +225,7 @@
                 {{ environment.name }}
               </div>
             </div>
-          </div> -->
+          </div> --\>
           <select class="ui floating labeled icon selection dropdown" name="imageId" [(ngModel)]="tale.imageId" required>
             <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
               <img class="ui avatar image" [src]="env.icon | safe:'url'" />
@@ -91,8 +233,9 @@
             </option>
           </select>
         </div>
-      </form>
+      </form> -->
 
+      <!-- View Mode (read-only) -->
       <div class="ui list" *ngIf="!editing">
         <div class="item">
           <b>Category:</b>
@@ -101,6 +244,10 @@
         <div class="item">
           <b>Title:</b>
           {{ tale.title }}
+        </div>
+        <div class="item" *ngIf="creator">
+          <b>Created By:</b>
+          {{ creator.firstName }} {{ creator.lastName }}
         </div>
         <div class="item">
           <b>Authors:</b>
@@ -116,11 +263,12 @@
         </div>
         <div class="item">
           <b>License:</b>
-          {{ tale.licenseSPDY }}
+          {{ tale.licenseSPDX }}
         </div>
-        <div class="item" *ngIf="tale.publishInfo.length">
-          <b>Published location:</b>
-          {{ tale.publishInfo[0].uri }}
+        <div class="item">
+            <b>Published Location:</b>
+            <span *ngIf="tale.publishInfo && tale.publishInfo.length">{{ tale.publishInfo[0] }}</span>
+            <span *ngIf="!tale.publishInfo || !tale.publishInfo.length">This Tale has not been published</span>
         </div>
         <div class="item spaced">
           <b>Tale Specifics</b>
@@ -163,7 +311,7 @@
     </div>
   </div>
 
-  <div class="row" *ngIf="tale._accessLevel > 0">
+<!--div class="row" *ngIf="tale._accessLevel > 0">
     <div class="ten wide column">
       <button class="ui primary button" *ngIf="!editing" (click)="editTale()">
         Edit
@@ -175,5 +323,5 @@
         Save
       </button>
     </div>
-  </div>
+  </div-->
 </div>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -3,12 +3,12 @@
     <div class="sixteen wide column">
 
       <!-- Edit Mode (read/write for) -->
-      <div id="taleMetadataForm" class="ui form" *ngIf="tale._accessLevel > 1">
+      <form id="taleMetadataForm" #taleMetadataForm="ngForm" class="ui form" *ngIf="tale._accessLevel > 1">
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Title</label>
           <div class="field thirteen wide column">
-            <input placeholder="Enter a title..." type="text" [(ngModel)]="tale.title">
+            <input placeholder="Title is required." type="text" name="title" [(ngModel)]="tale.title" required>
           </div>
         </div>
 
@@ -17,7 +17,7 @@
           <div class="thirteen wide column" style="padding-left:0;">
             <h4 style="text-align: center">Created by <span style="color:#67c096">{{creator.firstName}} {{creator.lastName}}</span></h4>
 
-            <form class="ui form" *ngIf="tale.authors.length">
+            <form #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="tale.authors.length">
               <table class="ui table striped condensed">
                 <tr>
                   <th>First Name</th>
@@ -26,9 +26,9 @@
                   <th></th>
                 </tr>
                 <tr *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorHash">
-                  <td><input type="text" name="firstName_{{i}}" placeholder="Enter first name" [(ngModel)]="author.firstName" required></td>
-                  <td><input type="text" name="lastName_{{i}}" placeholder="Enter last name" [(ngModel)]="author.lastName" required></td>
-                  <td><input type="text" name="orcid_{{i}}" placeholder="Enter ORCID" [(ngModel)]="author.orcid" required></td>
+                  <td><input type="text" name="firstName_{{i}}" placeholder="First name is required." [(ngModel)]="author.firstName" required></td>
+                  <td><input type="text" name="lastName_{{i}}" placeholder="Last name is required." [(ngModel)]="author.lastName" required></td>
+                  <td><input type="text" name="orcid_{{i}}" placeholder="ORCID is required." [(ngModel)]="author.orcid" required></td>
                   <td><button class="ui tiny negative button" (click)="removeAuthor(author)"><i class="fas fa-trash"></i></button></td>
                 </tr>
               </table>
@@ -40,14 +40,14 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Category</label>
           <div class="field thirteen wide column">
-            <input placeholder="Choose a category..." type="text" [(ngModel)]="tale.category">
+            <input placeholder="Category is required." type="text" name="category" [(ngModel)]="tale.category" required>
           </div>
         </div>
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Environment</label>
           <div class="field thirteen wide column">
-              <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="tale.imageId" required>
+              <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="tale.imageId">
                   <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
                   <img class="ui avatar image" [src]="env.icon | safe:'url'" />
                   {{ env.name }}
@@ -71,7 +71,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">License</label>
           <div class="field thirteen wide column">
-              <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX" required>
+              <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX">
                   <option class="item" [ngValue]="license.spdx" *ngFor="let license of (licenses | async); index as i; trackBy: trackBySpdx">
                   {{ license.name }}
                   </option>
@@ -119,7 +119,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Illustration</label>
           <div class="ui action field thirteen wide column">
-            <input placeholder="http://" type="text" [(ngModel)]="tale.illustration">
+            <input placeholder="http://" type="text" name="icon" [(ngModel)]="tale.illustration">
             <div class="or"></div>
             <button class="ui blue button" (click)="generateIcon()">Generate Illustration</button>
           </div>
@@ -136,7 +136,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned"></label>
           <div class="field two wide right aligned column">
-            <button class="ui blue submit button" (click)="updateTale()">Save</button>
+            <button class="ui blue submit button" [disabled]="!taleMetadataForm.valid" (click)="updateTale()">Save</button>
           </div>
 
           <div class="field toggle ui checkbox four wide column">
@@ -146,7 +146,17 @@
             <label>Public?</label>
           </div>
         </div>
-      </div>
+
+        <!--vdiv class="inline fields ui grid">
+          <label class="two wide column right aligned">Validation Errors</label>
+          <span *ngIf="taleMetadataForm.valid">No errors - Tale is valid!</span>
+          <ul *ngIf="!taleMetadataForm.valid" style="max-width:60vw">
+              <li *ngFor="let error of taleMetadataForm.errors">
+                  <pre>{{ error | json }}</pre>
+              </li>
+          </ul>
+        </div> -->
+      </form>
 
       <!-- View Mode (read-only) -->
       <div class="ui grid" *ngIf="tale._accessLevel <= 1">

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.scss
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.scss
@@ -11,3 +11,12 @@
   width: 100%;
   padding-right: 0;
 }
+
+#taleMetadataForm .ng-valid[required]:not(form),
+.ng-valid.required:not(form) {
+  border-left: 5px solid rgb(139, 196, 74); /* green */
+}
+
+#taleMetadataForm .ng-invalid:not(form) {
+  border-left: 5px solid #a94442; /* red */
+}

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -60,7 +60,7 @@ export class TaleMetadataComponent implements OnInit {
       $('#environmentDropdown:parent').dropdown().css('width', '100%');
       $('#licenseDropdown:parent').dropdown().css('width', '100%');
       this.saveState();
-    }, 500);
+    }, 800);
   }
 
   canDeactivate(): boolean {

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -14,6 +14,7 @@ import { ErrorService } from '@shared/error-handler/services/error.service';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { Observable } from 'rxjs';
 
+
 // import * as $ from 'jquery';
 declare var $: any;
 
@@ -32,16 +33,12 @@ export class TaleMetadataComponent implements OnInit {
   @Input() creator: User;
 
   licenses: Observable<Array<License>>;
-
   environments: Observable<Array<Image>>;
-  environment: Image;
-  newAuthor: TaleAuthor;
 
   apiRoot: string;
 
   // Edit mode
   _previousState: Tale;
-  editing = false;
 
   constructor(private ref: ChangeDetectorRef,
               private zone: NgZone,
@@ -53,42 +50,51 @@ export class TaleMetadataComponent implements OnInit {
               private errorHandler: ErrorService,
               private imageService: ImageService) {
     this.apiRoot = this.config.rootUrl;
-    this.resetNewAuthor();
   }
 
   ngOnInit(): void {
     const params = {};
     this.environments = this.imageService.imageListImages(params);
     this.licenses = this.licenseService.licenseGetLicenses();
+    setTimeout(() => {
+      $('#environmentDropdown:parent').dropdown().css('width', '100%');
+      $('#licenseDropdown:parent').dropdown().css('width', '100%');
+      this.saveState();
+    }, 500);
   }
 
-  ngOnChanges(): void {
-    this.editing = this.tale._accessLevel > 1;
-    this.ref.detectChanges();
-    if (this.editing) {
-      setTimeout(() => {
-        $('#environmentDropdown:parent').dropdown().css('width', '100%');
-        $('#licenseDropdown:parent').dropdown().css('width', '100%');
-      }, 500);
-    }
+  canDeactivate(): boolean {
+    // TODO: Revert to last known _previousState
+    // TODO: Ask for confirmation, if yes then
+    this.tale = this.copy(this._previousState);
+    // and then
+    return true;
+  }
+
+  saveState(): void {
+    this._previousState = this.copy(this.tale);
+  }
+
+  revertState(): void {
+    this.zone.run(() => {
+      this.tale = this.copy(this._previousState);
+    });
+  }
+
+  copy(obj: any): Tale {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  trackBySpdx(index: number, license: License): string {
+    return license.spdx;
   }
 
   trackById(index: number, model: any): string {
     return model._id || model.orcid || model.itemId;
   }
 
-  // TODO: Abstract to generic helper method
-  copy(json: any): any {
-    return JSON.parse(JSON.stringify(json));
-  }
-
-  editTale(): void {
-    this._previousState = this.copy(this.tale);
-    this.editing = true;
-    setTimeout(() => {
-      $('#environmentDropdown:parent').dropdown().css('width', '100%');
-      $('#licenseDropdown:parent').dropdown().css('width', '100%');
-    }, 500);
+  trackByAuthorHash(index: number, author: TaleAuthor): number {
+    return index;
   }
 
   updateTale(): Promise<any> {
@@ -102,6 +108,7 @@ export class TaleMetadataComponent implements OnInit {
     const promise = this.taleService.taleUpdateTale(params).toPromise()
     promise.then(res => {
       this.logger.debug("Successfully saved tale state:", this.tale);
+      this.saveState();
       this.zone.run(() => {
         this.notificationService.showSuccess("Tale saved successfully");
       });
@@ -129,26 +136,8 @@ export class TaleMetadataComponent implements OnInit {
     return errors;
   }
 
-  saveTaleEdit(): void {
-    const params = { id: this.tale._id , tale: this.tale };
-    this.updateTale().then(res => {
-      this.editing = false;
-    });
-  }
-
-  cancelTaleEdit(): void {
-    this.tale = this.copy(this._previousState);
-    this.editing = false;
-  }
-
-  addAuthor(author: TaleAuthor): void {
-    this.tale.authors.push(author);
-    this.resetNewAuthor();
-  }
-
   addNewAuthor(): void {
     this.tale.authors.push({ firstName: '', lastName: '', orcid: '' });
-    this.resetNewAuthor();
   }
 
   removeAuthor(author: TaleAuthor): void {
@@ -156,11 +145,7 @@ export class TaleMetadataComponent implements OnInit {
     this.tale.authors.splice(index, 1);
   }
 
-  resetNewAuthor(): void {
-    this.newAuthor = {
-      firstName: '',
-      lastName: '',
-      orcid: ''
-    };
+  generateIcon(): void {
+    this.tale.illustration = 'http://lorempixel.com/400/400/abstract/';
   }
 }


### PR DESCRIPTION
## Problem
Metadata view is missing some necessary information and styling does not very closely match the mockups.

Fixes #47 
Fixes #17 (but may still need very minor spacing fixes on read-only metadata view)

## Approach
Replace edit/save/cancel with static views that more closely match the mockups provided [here](https://whole-tale.github.io/wholetale-css-mockup/src/run-meta.html).

## How to Test
Prerequisites: at least one Tale created (Owned Tale, does not need to be running), at least one dataset registered

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog
4. Locate a Tale that you own and click View
5. Click the Files tab to go to the Run > Files view, then attach one or more External Datasets to the Tale
6. Click the Metadata tab to go to the Run > Metadata view
    * You should see a read/write view of the Tale's metadata, allowing you to edit the fields and Save
    * You should see that required `input` fields now show a green border on their left side
    * You should see Citations listed for each of the datasets you've added to the Tale
7. Add an author without filling out Name or ORCID, then scroll to the bottom
    * You should see that invalid fields, such as an `input` that is `required` but empty, are given a red border
    * You should see that the Save button is disabled if a required field is empty
8. Fill in the author's first name, last name, and ORCID
9. Modify the title, category, environment, license, description, and illustration (optional) and click Save
    * You should **not** be able to clear the value of the environment or license dropdowns
    * You should see a notification indicating that the Tale was saved successfully
