### PR TITLE
fix: remove the folder from the user's view and component

### DIFF
--- a/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.html
@@ -46,10 +46,6 @@
           </div>
           
           <div class="ui tertiary segment white-bg" *ngIf="selectedResult">
-            <div class="inline field">
-              <label>Folder Name</label>
-              <input [(ngModel)]="registrationFolderName" type="text">
-            </div>
             <p>DOI: {{ selectedResult.doi }}</p>
             <p>DataID: {{ selectedResult.dataId }}</p>
             <p>Repository: {{ selectedResult.repository }}</p>

--- a/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.ts
@@ -12,7 +12,6 @@ export class RegisterDataDialogComponent {
 
   registrationError = '';
   registrationUrl = '';
-  registrationFolderName = '';
 
   showSearchResults = false;
   searchResultsLoading = false;
@@ -45,12 +44,6 @@ export class RegisterDataDialogComponent {
       this.logger.error(`Failed to search for dataId=${this.registrationUrl}:`, err);
       this.searchResultsLoading = false;
     });
-  }
-
-  onSelectedResultChanged(result: any): void {
-    if (event) {
-      this.registrationFolderName = result.name;
-    }
   }
 
   trackByDataId(index: number, dataset: any): string {


### PR DESCRIPTION
## Problem
Fixes #93 
  
## Approach
This PR removes the text box that allowed users to enter a folder name.
  
## How to Test
1. Open the register data modal (I went to Tale->Files->Add External Data)
2. Enter a doi or URL (eg doi:10.18739/A2M61BQ8M)
3. Search for the data
4. Select the result
5. Note that there isn't a field for the folder name


<img width="803" alt="Screen Shot 2020-08-26 at 6 50 13 PM" src="https://user-images.githubusercontent.com/9289652/91374408-010a8500-e7cd-11ea-9c96-73e7410327d3.png">
