### PR TITLE
feat: add move-to-dialog for changing parent folder

### DIFF
--- a/src/app/+run-tale/run-tale.module.ts
+++ b/src/app/+run-tale/run-tale.module.ts
@@ -9,6 +9,7 @@ import { TruncatePipe } from '@framework/core/truncate.pipe';
 import { MaterialModule } from '@framework/material';
 import { TaleCreatorPipe } from '@tales/pipes/tale-creator.pipe';
 import { TaleImagePipe } from '@tales/pipes/tale-image.pipe';
+import { TaleNamePipe } from '@tales/pipes/tale-name.pipe';
 import { TalesModule } from '@tales/tales.module';
 import { MarkdownModule } from 'ngx-markdown';
 
@@ -25,7 +26,8 @@ import { TaleMetadataComponent } from './run-tale/tale-metadata/tale-metadata.co
 
 @NgModule({
   imports: [CommonModule, RouterModule.forChild(routes), SharedModule, MaterialModule, MatDialogModule, FilesModule, TalesModule, MarkdownModule.forRoot()],
-  providers: [TruncatePipe, SafePipe, TaleCreatorPipe, TaleImagePipe],
+  providers: [TruncatePipe, SafePipe, TaleCreatorPipe, TaleImagePipe, TaleNamePipe],
+  exports: [TaleCreatorPipe, TaleImagePipe, TaleNamePipe ],
   declarations: [
     RunTaleComponent,
     TaleFilesComponent,

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -522,20 +522,22 @@ export class TaleFilesComponent implements OnInit, OnChanges {
   moveElement(event: { element: FileElement; moveTo: FileElement }): void {
     const src = event.element;
     const dest = event.moveTo;
-    const params = { id: src._id, parentId: dest._id };
+    const params = { id: src._id, parentId: dest._id, parentType: ParentType.Folder, baseParentId: dest.baseParentId };
     if (src._modelType === 'folder') {
       // Element is a folder, move it
       this.folderService.folderUpdateFolder(params)
                         .pipe(enterZone(this.zone))
                         .subscribe(resp => {
-        this.logger.debug("Folder moved successfully:", resp);
+        this.logger.info("Folder moved successfully:", resp);
+        this.load();
       });
     } else if (src._modelType === 'item') {
       // Element is an item, move it
       this.itemService.itemUpdateItem(params)
                       .pipe(enterZone(this.zone))
                       .subscribe(resp => {
-        this.logger.debug("Item moved successfully:", resp);
+        this.logger.info("Item moved successfully:", resp);
+        this.load();
       });
     }
   }

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -521,9 +521,9 @@ export class TaleFilesComponent implements OnInit, OnChanges {
 
   moveElement(event: { element: FileElement; moveTo: FileElement }): void {
     const src = event.element;
-    const dest = event.moveTo;
-    const params = { id: src._id, parentId: dest._id, parentType: ParentType.Folder, baseParentId: dest.baseParentId };
+    const dest = event.moveTo;;
     if (src._modelType === 'folder') {
+      const params = { id: src._id, parentId: dest._id, parentType: ParentType.Folder, baseParentId: dest.baseParentId }
       // Element is a folder, move it
       this.folderService.folderUpdateFolder(params)
                         .pipe(enterZone(this.zone))
@@ -532,6 +532,7 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         this.load();
       });
     } else if (src._modelType === 'item') {
+      const params = { id: src._id, folderId: dest._id, baseParentId: dest.baseParentId }
       // Element is an item, move it
       this.itemService.itemUpdateItem(params)
                       .pipe(enterZone(this.zone))

--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -65,8 +65,8 @@
               <div *ngIf="!readOnlyDropdown" class="item" (click)="renameElement(ele)"><i class="fas fa-edit"></i> Rename</div>
               <div *ngIf="!readOnlyDropdown" class="item" (click)="removeElement(ele)"><i class="fas fa-trash"></i> Remove</div>
               <div class="item" (click)="downloadElement(ele)"><i class="fas fa-download"></i> Download</div>
-              <div *ngIf="!readOnlyDropdown" class="item" (click)="moveElement(ele)"><i class="fas fa-exchange-alt"></i> Move To...</div>
-              <div *ngIf="!readOnlyDropdown" class="item" (click)="copyElement(ele)"><i class="fas fa-clone"></i> Copy To...</div>
+              <div *ngIf="!readOnlyDropdown" class="item" (click)="openMoveToDialog(ele)"><i class="fas fa-exchange-alt"></i> Move To...</div>
+              <div *ngIf="!readOnlyDropdown" class="item" (click)="copyElement(ele)"><i class="fas fa-clone"></i> Copy</div>
             </div>
           </div>
         </td>

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -4,6 +4,7 @@ import { Tale } from '@api/models/tale';
 import { FileElement } from '@files/models/file-element';
 import { LogService } from '@framework/core/log.service';
 
+import { MoveToDialogComponent } from './modals/move-to-dialog/move-to-dialog.component';
 import { NewFolderDialogComponent } from './modals/new-folder-dialog/new-folder-dialog.component';
 import { RenameDialogComponent } from './modals/rename-dialog/rename-dialog.component';
 
@@ -106,7 +107,7 @@ export class FileExplorerComponent implements OnInit {
   @Output() readonly elementRenamed = new EventEmitter<FileElement>();
   @Output() readonly elementCopied = new EventEmitter<FileElement>();
   @Output() readonly elementDownloaded = new EventEmitter<FileElement>();
-  @Output() readonly elementMoved = new EventEmitter<{ element: FileElement; moveTo: FileElement }>();
+  @Output() readonly elementMoved = new EventEmitter<{ element: FileElement; moveTo?: FileElement }>();
   @Output() readonly navigatedDown = new EventEmitter<FileElement>();
   @Output() readonly navigatedUp = new EventEmitter();
 
@@ -183,12 +184,21 @@ export class FileExplorerComponent implements OnInit {
     this.navigatedUp.emit();
   }
 
-  moveElement(element: FileElement, moveTo: FileElement): void {
+  moveElement(element: FileElement): void {
     // Don't navigate if selecting a dropdown option
     event.stopPropagation();
 
-    // TODO: Prompt user to select target folder?
-    this.elementMoved.emit({ element, moveTo });
+    this.elementMoved.emit({ element });
+  }
+
+  openMoveToDialog(element: FileElement): void {
+    const dialogRef = this.dialog.open(MoveToDialogComponent, { data: { elementToMove: element } });
+    dialogRef.afterClosed().subscribe((moveTo: FileElement) => {
+      if (moveTo) {
+        this.logger.info(`Moving ${element._modelType}Id=${element._id} to new parent:`, moveTo);
+        this.elementMoved.emit({ element, moveTo });
+      }
+    });
   }
 
   openNewFolderDialog(): void {

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.html
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.html
@@ -1,0 +1,82 @@
+<h1 mat-dialog-title>Move Item: {{ data.elementToMove.name | truncate:titleTruncateLength }}</h1>
+
+<mat-dialog-content>
+    <table class="ui compact striped table">
+        <!-- If we're in a folder, show the name of the folder -->
+        <thead *ngIf="currentRoot">
+          <th colspan="5" class="ui sub header collapsing noselect clickable blue" (click)="navigateUp()">
+              <span class="long alternate blue">
+                <i class="horizontally flipped level up icon"></i>
+                <span *ngIf="pathStack.length !== 2 || pathStack[0] !== wsRoot" title="{{currentRoot.name}}">
+                    {{ currentRoot.name | truncate:headTruncateLength }}
+                </span>
+                <span *ngIf="pathStack.length === 2 && pathStack[0] === wsRoot && (currentRoot.name | taleName | async) as taleTitle"
+                      title="{{taleTitle}} ({{currentRoot.name}})">
+                    {{ taleTitle | truncate:headTruncateLength }}
+                </span>
+              </span>
+          </th>
+        </thead>
+
+        <!-- If Workspaces is selected, translate taleIds into titles and show special tooltip -->
+        <tbody *ngIf="currentRoot && currentRoot === wsRoot && (folders | async).concat(files | async) as contents">
+          <tr *ngIf="!contents.length">{{ placeholderMessage }}</tr>
+          <tr [ngClass]="{
+                    'active': selectedFolder === elem,
+                    'clickable': elem._modelType === 'folder',
+                    'disabled not clickable': elem._modelType !== 'folder' || data.elementToMove._id === elem._id }"
+                *ngFor="let elem of contents; index as i; trackBy:trackById"
+                (click)="selectFolder(elem)"
+                (dblclick)="navigate(elem)">
+            <td>
+                <i class="fas fa-fw" [ngClass]="{
+                  'fa-folder': elem._modelType === 'folder',
+                  'fa-file': elem._modelType === 'item' || elem._modelType === 'file' }"></i>
+            </td>
+            <td *ngIf="(elem.name | taleName | async) as taleTitle" title="{{taleTitle}} ({{elem.name}})">
+                {{ taleTitle | truncate:bodyTruncateLength }}
+            </td>
+          </tr>
+        </tbody>
+
+        <!-- If any other folder is selected, just display title as-is -->
+        <tbody *ngIf="currentRoot && currentRoot !== wsRoot && (folders | async).concat(files | async) as contents">
+          <tr *ngIf="!contents.length">{{ placeholderMessage }}</tr>
+          <tr [ngClass]="{
+                'active': selectedFolder === elem,
+                'clickable': elem._modelType === 'folder',
+                'disabled not clickable': elem._modelType !== 'folder' || data.elementToMove._id === elem._id }"
+              *ngFor="let elem of contents; index as i; trackBy:trackById"
+              (click)="selectFolder(elem)"
+              (dblclick)="navigate(elem)">
+            <td>
+                <i class="fas fa-fw" [ngClass]="{
+                    'fa-folder': elem._modelType === 'folder',
+                    'fa-file': elem._modelType === 'item' || elem._modelType === 'file' }"></i>
+            </td>
+            <td title="{{elem.name}}">{{ elem.name | truncate:bodyTruncateLength }}</td>
+          </tr>
+        </tbody>
+
+        <!-- If no currentFolderId, show the root Home / Workspaces for selection -->
+        <tbody *ngIf="!currentRoot">
+          <tr class="clickable" [ngClass]="{ 'active': selectedFolder === homeRoot }"
+                (click)="selectFolder(homeRoot)" (dblclick)="navigate(homeRoot)">
+            <td><i class="fas fa-fw fa-folder"></i></td>
+            <td>Home</td>
+          </tr>
+          <tr class="clickable" (click)="navigate(wsRoot)" (dblclick)="navigate(wsRoot)">
+            <td><i class="fas fa-fw fa-folder"></i></td>
+            <td>Tale Workspaces</td>
+          </tr>
+        </tbody>
+    </table>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button class="ui black deny button" mat-dialog-close>Cancel</button>
+  <button class="ui positive right labeled icon button" [disabled]="!selectedFolder" [mat-dialog-close]="selectedFolder">
+    Confirm
+    <i class="checkmark icon"></i>
+  </button>
+</mat-dialog-actions>

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.scss
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.scss
@@ -1,0 +1,7 @@
+.clickable {
+  cursor: pointer !important;
+}
+
+.not.clickable {
+  cursor: not-allowed !important;
+}

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.spec.ts
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MoveToDialogComponent } from './move-to-dialog.component';
+
+describe('MoveToDialogComponent', () => {
+  let component: MoveToDialogComponent;
+  let fixture: ComponentFixture<MoveToDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [MoveToDialogComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MoveToDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
@@ -1,0 +1,213 @@
+import { Component, Inject, NgZone, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import { User } from '@api/models/user';
+import { CollectionService } from '@api/services/collection.service';
+import { DatasetService } from '@api/services/dataset.service';
+import { FileService } from '@api/services/file.service';
+import { FolderService } from '@api/services/folder.service';
+import { ItemService } from '@api/services/item.service';
+import { ResourceService } from '@api/services/resource.service';
+import { TaleService } from '@api/services/tale.service';
+import { UserService } from '@api/services/user.service';
+import { WorkspaceService } from '@api/services/workspace.service';
+import { FileElement } from '@files/models/file-element';
+import { LogService } from '@framework/core/log.service';
+import { TruncatePipe } from '@framework/core/truncate.pipe';
+import { WindowService } from '@framework/core/window.service';
+import { enterZone } from '@framework/ngrx/enter-zone.operator';
+import { TaleNamePipe } from '@tales/pipes/tale-name.pipe';
+import { BehaviorSubject, forkJoin, Observable } from 'rxjs';
+
+const URL = window['webkitURL'] || window.URL; // tslint:disable-line
+
+// TODO: Is there a better place to store these constants?
+const HOME_ROOT_NAME = 'Home';
+const DATA_ROOT_PATH = '/collection/WholeTale Catalog/WholeTale Catalog';
+const WORKSPACES_ROOT_PATH = '/collection/WholeTale Workspaces/WholeTale Workspaces';
+
+const MAX_PATH_SEGMENT_LENGTH = 15;
+
+const HOME_PATH_SEGMENT = 'Home';
+const TALE_WORKSPACES_PATH_SEGMENT = 'Tale Workspaces';
+
+enum ParentType {
+  Folder = 'folder',
+  Collection = 'collection',
+  User = 'user'
+}
+
+@Component({
+  templateUrl: './move-to-dialog.component.html',
+  styleUrls: ['./move-to-dialog.component.scss']
+})
+export class MoveToDialogComponent implements OnInit {
+  selectedFolder: FileElement;
+  homeRoot: FileElement;
+  wsRoot: FileElement;
+
+  titleTruncateLength = 20;
+  headTruncateLength = 40;
+  bodyTruncateLength = 65;
+
+  folders: BehaviorSubject<Array<FileElement>> = new BehaviorSubject<Array<FileElement>>([]);
+  files: BehaviorSubject<Array<FileElement>> = new BehaviorSubject<Array<FileElement>>([]);
+
+  pathStack: Array<FileElement> = [];
+
+  get currentFolderId(): string {
+    const lastItem = this.currentRoot;
+    if (!lastItem) {
+      return undefined;
+    }
+    return lastItem._id;
+  }
+
+  get currentRoot(): FileElement {
+    if (this.pathStack.length === 0) {
+      return undefined;
+    }
+
+    const lastIndex = this.pathStack.length - 1;
+    const lastItem = this.pathStack[lastIndex];
+    return lastItem;
+  }
+
+  // NOTE: currently unused
+  get currentPath(): string {
+    return this.pathStack
+      .map((e: FileElement) => {
+        if (e._id === this.homeRoot._id) {
+          return HOME_PATH_SEGMENT;
+        } else if (e._id === this.wsRoot._id) {
+          return TALE_WORKSPACES_PATH_SEGMENT;
+        } else if (e.parentId === this.wsRoot._id) {
+          // Fetch Tale via ID, then display its title
+          return (async () => {
+            const taleId = e.name;
+            return this.taleNamePipe.transform(taleId).toPromise();
+          })();
+        } else {
+          return e.name;
+        }
+      })
+      .join('/');
+  }
+
+  get placeholderMessage(): string {
+    if (this.pathStack.length === 2 && this.pathStack[0] === this.wsRoot) {
+      return 'This Tale\'s Workspace is empty.'; // Empty Tale Workspace
+    } else if (this.pathStack.length === 1 && this.pathStack[0] === this.wsRoot) {
+      return 'You have not created any Tales.'; // Empty Tale Workspaces folder
+    } else if (this.pathStack.length === 1 && this.pathStack[0] === this.homeRoot) {
+      return 'Your Home folder is empty.'; // Empty home folder placeholder
+    } else {
+      return 'This folder is empty.'; // Empty generic sub-folder
+    }
+  }
+
+  constructor(
+    private readonly zone: NgZone,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute,
+    private readonly logger: LogService,
+    private readonly folderService: FolderService,
+    private readonly collectionService: CollectionService,
+    private readonly itemService: ItemService,
+    private readonly workspaceService: WorkspaceService,
+    private readonly fileService: FileService,
+    private readonly userService: UserService,
+    private readonly taleService: TaleService,
+    private readonly resourceService: ResourceService,
+    private readonly taleNamePipe: TaleNamePipe,
+    @Inject(MAT_DIALOG_DATA) public data: { elementToMove: FileElement }
+  ) {}
+
+  ngOnInit(): void {
+    // Fetch Home root
+    this.userService.userGetMe().subscribe((user: User) => {
+      const homeRootParams = { parentId: user._id, parentType: ParentType.User, text: HOME_ROOT_NAME };
+      const wsRootParams = { test: false, path: WORKSPACES_ROOT_PATH };
+
+      const homeFind = this.folderService.folderFind(homeRootParams);
+      const wsFind = this.resourceService.resourceLookup(wsRootParams);
+
+      // Fetch all root folders before loading
+      forkJoin(homeFind, wsFind)
+        .pipe(enterZone(this.zone))
+        .subscribe((value: Array<any>) => {
+          if (value.length < 2) {
+            this.logger.error('Error: Value mismatch when fetching root folders');
+          }
+
+          const homeFolderResults = value[0];
+
+          if (homeFolderResults && homeFolderResults.length) {
+            this.homeRoot = homeFolderResults[0];
+          }
+
+          this.wsRoot = value[1];
+
+          this.load();
+        });
+    });
+  }
+
+  load(): void {
+    if (!this.currentFolderId) {
+      // Home folder actually works withthis same logic
+      return;
+    }
+
+    // Fetch folders in the current folder
+    this.folderService
+      .folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder })
+      .pipe(enterZone(this.zone))
+      .subscribe(folders => {
+        this.folders.next(folders);
+      });
+    // Fetch items in the current folder
+    this.itemService
+      .itemFind({ folderId: this.currentFolderId })
+      .pipe(enterZone(this.zone))
+      .subscribe(items => {
+        this.files.next(items);
+      });
+  }
+
+  // De-select folder, push to path, and reload list
+  navigate(elem: FileElement): void {
+    if (!elem || elem._modelType !== 'folder') {
+      this.logger.warn('Attempted to navigate into a non-folder: ', elem);
+      return;
+    }
+
+    this.selectedFolder = undefined;
+    this.pathStack.push(elem);
+    this.load();
+  }
+
+  // De-select folder, pop from path, and reload list
+  navigateUp(): void {
+    if (!this.pathStack.length) {
+      this.logger.warn('Attempted to pop from empty path: ', this.pathStack);
+      return;
+    }
+
+    this.selectedFolder = undefined;
+    const poppedItem = this.pathStack.pop();
+    this.load();
+  }
+
+  // Select folder
+  selectFolder(elem: FileElement) {
+    if (!elem || elem._modelType !== 'folder') {
+      this.logger.warn('Attempted to select a non-folder: ', elem);
+      return;
+    } else if (elem._id === this.data.elementToMove._id) {
+      this.logger.warn('Attempted to move the current item into itself: ', elem);
+      return;
+    }
+    this.selectedFolder = elem;
+  }
+}

--- a/src/app/files/files.module.ts
+++ b/src/app/files/files.module.ts
@@ -11,15 +11,17 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { SharedModule } from '@framework/core';
 import { MaterialModule } from '@framework/material';
+import { TalesModule } from '@tales/tales.module';
 
 import { FileExplorerComponent } from './file-explorer/file-explorer.component';
+import { MoveToDialogComponent } from './file-explorer/modals/move-to-dialog/move-to-dialog.component';
 import { NewFolderDialogComponent } from './file-explorer/modals/new-folder-dialog/new-folder-dialog.component';
 import { RenameDialogComponent } from './file-explorer/modals/rename-dialog/rename-dialog.component';
 import { FilesService } from './files.service';
 import { FileSizePipe } from './filesize.pipe';
 
 @NgModule({
-  declarations: [FileExplorerComponent, NewFolderDialogComponent, RenameDialogComponent, FileSizePipe],
+  declarations: [FileExplorerComponent, NewFolderDialogComponent, RenameDialogComponent, FileSizePipe, MoveToDialogComponent],
   exports: [FileExplorerComponent, FileSizePipe],
   providers: [FilesService, DecimalPipe],
   imports: [
@@ -34,8 +36,9 @@ import { FileSizePipe } from './filesize.pipe';
     MatMenuModule,
     MatInputModule,
     MatButtonModule,
-    FormsModule
+    FormsModule,
+    TalesModule
   ],
-  entryComponents: [NewFolderDialogComponent, RenameDialogComponent]
+  entryComponents: [NewFolderDialogComponent, RenameDialogComponent, MoveToDialogComponent]
 })
 export class FilesModule {}

--- a/src/app/tales/pipes/tale-name.pipe.ts
+++ b/src/app/tales/pipes/tale-name.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Tale } from '@api/models/tale';
+import { TaleService } from '@api/services/tale.service';
+import { EMPTY, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+// Given a taleId, fetch and return the Tale's title
+@Pipe({ name: 'taleName' })
+export class TaleNamePipe implements PipeTransform {
+  constructor(private readonly taleService: TaleService) {}
+
+  transform(taleId: string): Observable<string> {
+    if (!taleId) {
+      return EMPTY;
+    }
+
+    return this.taleService.taleGetTale(taleId).pipe(map((t: Tale) => t.title));
+  }
+}

--- a/src/app/tales/tales.module.ts
+++ b/src/app/tales/tales.module.ts
@@ -7,13 +7,15 @@ import { TalesService } from '@tales/tales.service';
 
 import { CopyOnLaunchModalComponent } from './components/modals/copy-on-launch-modal/copy-on-launch-modal.component';
 import { TaleRunButtonComponent } from './components/tale-run-button/tale-run-button.component';
+
 import { TaleCreatorPipe } from './pipes/tale-creator.pipe';
 import { TaleImagePipe } from './pipes/tale-image.pipe';
+import { TaleNamePipe } from './pipes/tale-name.pipe';
 
 @NgModule({
-  declarations: [CopyOnLaunchModalComponent, TaleRunButtonComponent, TaleCreatorPipe, TaleImagePipe],
-  exports: [TaleRunButtonComponent, CopyOnLaunchModalComponent, TaleCreatorPipe, TaleImagePipe],
-  providers: [TalesService],
+  declarations: [CopyOnLaunchModalComponent, TaleRunButtonComponent, TaleCreatorPipe, TaleImagePipe, TaleNamePipe],
+  exports: [TaleRunButtonComponent, CopyOnLaunchModalComponent, TaleCreatorPipe, TaleImagePipe, TaleNamePipe],
+  providers: [TalesService, TaleNamePipe],
   imports: [CommonModule, SharedModule, MaterialModule, MatDialogModule],
   entryComponents: [CopyOnLaunchModalComponent]
 })


### PR DESCRIPTION
## Problem
The MoveTo dialog was never implemented. There is already some code written that can work as a callback that this modal should execute after submission.

Fixes #40 
Fixes #92 
Fixes #91

## Approach
* Implement the MoveToDialog, allowing user to change the parent folder of a given file or folder

* NOTE: This approach currently encounters issues when moving from a Tale Workspace to Home, and likely vice versa. I may be missing some bits about setting `baseParentId` properly when shifting between data sources. Unless it's an easy fix, this will likely be addressed in a follow-up ticket.

## How to Test
Prerequisites: at least one Tale created, at least two folders created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
4. Navigate to Run > Files > Home or Run > Files > Tale Workspace
5. Create two folders here, called "Folder A" and "Folder B"
6. Expand the dropdown beside "Folder B" and choose "Move To..."
    * You should see the MoveToDialog now appear
    * You should be offered a file browser with "Home" and "Tale Workspaces" at the top level
7. Click into Tale Workspaces
    * You should see the names of all Tales listed here
    * Hovering over a Tale name, you should see its ID
8. Double-click (not click) a Tale name to navigate into its Workspace
    * You should **not** be able to select "Tale Workspaces" - this prevents the users from selecting it as a destination
    * You should be brought into the Workspace
    * You should see the Tale's name at the top of the file browser, indicating that you can click it to navigate back up
    * You should not be able to select any files (they are disabled).. only folders are allowed
9. Click the blue header / up arrow twice to go back to the root
10. Double-click Home to navigate into it
    * You should see the contents of your Home folder are listed here
    * You should not be able to select any files (they are disabled).. only folders are allowed
11. Choose / select "Folder A" using single-click, and then click Confirm
    * You should see the modal now close
    * You should see your file disappear from the parent file browser view (it has moved!)
12. Navigate into "Folder A"
    * You should see "Folder B" sitting here
