### PR TITLE
fix: explicitly update tales$ binding when deleting

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -130,6 +130,9 @@ export class PublicTalesComponent implements OnChanges, OnInit {
       const id = tale._id;
       this.taleService.taleDeleteTale({ id }).subscribe(response => {
         this.logger.debug("Successfully deleted Tale:", response);
+
+        // Explicitly force Tale list binding to refresh
+        this.tales$ = this.taleService.taleListTales({});
         this.refresh();
       }, err => {
           this.logger.error("Failed to delete Tale:", err);


### PR DESCRIPTION
## Problem
When deleting a Tale from the catalog, it would remain in view.

Fixes #39 

## Approach
Easy fix, but very annoying to track down what was causing it. This is probably a pattern problem with how I have implemented the catalog views.

This is probably bad practice long-term, but the two edge cases that collide here are:
1. It is unclear how often Tales are actually deleted (typically, users are bad at cleaning up zero-cost resources)
2. It is unclear how often the average user refreshes their current browser tab, and not doing so may have consequences sif  RxJS streams are not handled properly ... I may need to read up more about cleanup here

## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
    * You should be brought to the Run > Metadata view
4. Click your browser's Back button
    * You should be brought back to the Tale Catalog view
5. Hover over the Tale and click the red X at the bottom right of the illustration
    * You should see a dialog open, prompting you for confirmation to Delete the Tale
6. Click Confirm to Delete the Tale
    * You should see the dialog close
    * You should see the Tale remove from view (there may be a slight delay)
7. Refresh the view
    * You should see the Tale does not return