### PR TITLE
fix: various small navbar fixes

### DIFF
--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,7 +5,9 @@
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
-      <a class="item"><i class="info circle white icon"></i></a>
+      <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/">
+        <i class="info circle white icon"></i>
+      </a>
       <a class="item" (click)="toggleNotificationStream()">
         <i class="tasks white icon"></i>
         <div id="event-notification-counter" class="floating ui red label" *ngIf="eventCount > 0">
@@ -13,10 +15,16 @@
         </div>
       </a>
       <div class="ui right dropdown link item">
-        <span class="text"><i class="user circle white icon"></i></span>
+        <span class="text">
+            <img *ngIf="user?.gravatar_baseUrl" class="ui avatar image gravatar" [src]="user.gravatar_baseUrl">
+            <i *ngIf="!user?.gravatar_baseUrl" class="user circle white icon"></i>
+        </span>
         <div class="menu" tabindex="-1">
-          <div class="item" *ngIf="user && user.gravatar_baseUrl"><img class="gravatar" [src]="user.gravatar_baseUrl">{{ user.firstName }} {{ user.lastName }}</div>
-          <div class="divider"></div>
+          <div id="avatar-item" class="disabled item" *ngIf="user && user.gravatar_baseUrl">
+            <img class="circle gravatar" [src]="user.gravatar_baseUrl">
+            {{ user.firstName }} {{ user.lastName }}
+        </div>
+          <div class="divider nomargin"></div>
           <div class="item"  routerLink="/settings" routerLinkActive="active">Settings</div>
           <div class="item" (click)="logout()">Logout</div>
         </div>

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -2,8 +2,8 @@
 <div class="ui inverted menu wt-top">
     <a class="header item wt-brand" routerLink="/public" routerLinkActive="active"><img src="assets/img/wholetale_logo_sm.png">Whole<span>Tale</span></a>
     <a class="item" [ngClass]="{ 'active':currentRoute==='/public' || currentRoute==='/mine' }" routerLink="/public" routerLinkActive="active">Tale Dashboard</a>
-    <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a>
-    <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a>
+    <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
+    <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
       <a class="item"><i class="info circle white icon"></i></a>
       <a class="item" (click)="toggleNotificationStream()">

--- a/src/app/layout/header.component.scss
+++ b/src/app/layout/header.component.scss
@@ -20,3 +20,16 @@
   -webkit-border-radius: 0;
   border-radius: 0;
 }
+
+.circle.gravatar {
+  border-radius: 100px;
+  height: 42px;
+}
+
+.nomargin {
+  margin: 0 !important;
+}
+
+#avatar-item {
+  opacity: 1;
+}

--- a/src/app/layout/notification-stream/notification-stream.component.scss
+++ b/src/app/layout/notification-stream/notification-stream.component.scss
@@ -1,7 +1,7 @@
 #notificationStream {
   position: fixed;
   background: lightgrey;
-  top: 20px;
+  top: 50px;
   right: 20px;
   max-height: 40vh;
   max-width: 40vw;
@@ -20,7 +20,7 @@
 
 /** Notification Stream styles */
 #event-notification-placeholder {
-  margin-top: 40px;
+  margin: 50px;
 }
 #event-notification-stream {
   position: fixed;


### PR DESCRIPTION
## Problem
The "Data Catalog" and "Compute Environment" links just contain static placeholder data.

## Approach
Hide these links for now until these views are functional and add more value to the platform.

Fixes #97 - Hide the links until these views are finished

Other minor fixes on this branch:
* Fixes #84 - Adjusted notification stream margins so it no longer overlaps with the navbar
* Added missing User Guide link to the navbar (clicking icon previously did nothing)
* Display avatar in the navbar when available, disabled menu item for avatar/username, as clicking it currently does nothing
  
## How to Test
Prerequisites: none

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
    * You should see only "Tale Dashboard" in the navbar
    * You should **not** see "Data Catalog" or "Compute Environments"
    * You should see your gravatar displayed in the navbar, if you have one set
3. Expand the Notification Stream panel
    * You should see the placeholder text for the notification stream is slightly more centered
4. Expand the user dropdown and hover over your name
    * Your cursor should not indicate that this item is clickable 
5. Click the (i) symbol in the navbar
     * You should be brought to the User Guide

