### PR TITLE
fix: add a width to first column to prevent whitespace on select-data-dialog

### DIFF
--- a/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.html
@@ -34,7 +34,7 @@
           <tbody *ngIf="selectedDataset">
             <tr *ngFor="let elem of (folders | async).concat(files | async); index as i; trackBy:trackById"
                 [ngClass]="{ 'clickable': elem._modelType === 'folder', 'active': isSelected(elem, datasetsToAdd) }" (click)="toggledCheckbox($event, elem, datasetsToAdd)" (dblclick)="navigateToFolder(elem)">
-              <td><i class="fas fa-fw" [ngClass]="{ 'fa-folder': elem._modelType === 'folder', 'fa-file': elem._modelType === 'item' || elem._modelType === 'file' }"></i></td>
+              <td class="icon-column"><i class="fas fa-fw" [ngClass]="{ 'fa-folder': elem._modelType === 'folder', 'fa-file': elem._modelType === 'item' || elem._modelType === 'file' }"></i></td>
               <td>{{ elem.name | truncate:65 }}</td>
               <!--<td>{{ elem.size | fileSize }}</td>
               <td [title]="elem.updated">{{ elem.updated | date }}</td>-->
@@ -48,7 +48,7 @@
             </tr>
             <tr  *ngFor="let dataset of (datasets | async); index as i; trackBy:trackById"
                 [ngClass]="{ 'clickable': dataset._modelType === 'folder', 'active': isSelected(dataset, datasetsToAdd) }" (click)="toggledCheckbox($event, dataset, datasetsToAdd)" (dblclick)="navigateIntoDataset(dataset)">
-              <td><i class="fas fa-fw" [ngClass]="{ 'fa-folder': dataset._modelType === 'folder', 'fa-file': dataset._modelType === 'item' }"></i></td>
+              <td class="icon-column"><i class="fas fa-fw" [ngClass]="{ 'fa-folder': dataset._modelType === 'folder', 'fa-file': dataset._modelType === 'item' }"></i></td>
               <td>{{ dataset.name | truncate:40 }}</td>
               <!--<td>{{ dataset.size | fileSize }}</td>
               <td [title]="dataset.updated">{{ dataset.updated | date }}</td>-->
@@ -70,7 +70,7 @@
             </tr>
             <tr *ngFor="let dataset of (addedDatasets | async); index as i; trackBy:trackById"
                 [ngClass]="{ 'clickable': dataset._modelType === 'folder', 'active': isSelected(dataset, datasetsToRemove) }" (click)="toggledCheckbox($event, dataset, datasetsToRemove)">
-              <td><i class="fas fa-fw" [ngClass]="{ 'fa-folder': dataset._modelType === 'folder', 'fa-file': dataset._modelType === 'item'}"></i></td>
+              <td class="icon-column"><i class="fas fa-fw" [ngClass]="{ 'fa-folder': dataset._modelType === 'folder', 'fa-file': dataset._modelType === 'item'}"></i></td>
               <td>{{ dataset.name | truncate:40 }}</td>
               <!--<td>{{ dataset.size | fileSize }}</td>
               <td [title]="dataset.updated">{{ dataset.updated | date }}</td>-->

--- a/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.scss
+++ b/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.scss
@@ -24,3 +24,7 @@
 .clickable {
   cursor: pointer !important;
 }
+
+.icon-column {
+  width: 2em;
+}


### PR DESCRIPTION
## Problem
Some HTTPS dataset subfolders appear to render with an excessive amount of space. 

Fixes #90 

## Approach
While I still don't know what was causing this problem, adding a `width` to the first column prevents it from taking up too much space in these cases.

Appears to be related to https://github.com/whole-tale/girder_wholetale/issues/304, but I have no idea how or why. This behavior seems to only manifest with these types of HTTPS resources.
 
## How to Test
Prerequisites: at least one Tale created that you own, at least one HTTPS dataset resource registered

Example: Register https://raw.githubusercontent.com/whole-tale/dashboard/master/.travis.yml

Ideally: many different datasets registered

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog and choose "My Tales"
4. Scroll to a Tale that you own and click View
    * You should be brought to the Run > Metadata view
5. Click the "Files" tab
    * You should be brought to the Run > Files view
6. On the left side, click "External Data"
    * You should see the right side file browser change to show attached datasets
7. Click the (+) button at the top-right and choose "WT Data Catalog"
    * You should see the select-data modal appear
8. On the left side of the modal, click on "WT Catalog"
    * You should see the right side of the modal change to show the full data catalog
9. From the list, double-click an HTTPS resource (these usually appear as URLs)
    * You should see the name of the dataset you just clicked now appears in blue at the top
    * You should see the contents of this folder are now shown
    * You should see that the first column (with the folder icon) does **not** take up an unreasonable amount of space 