### PR TITLE
Remove unused workspaceModified field

### DIFF
--- a/src/app/tales/models/tale.ts
+++ b/src/app/tales/models/tale.ts
@@ -26,7 +26,6 @@ export interface Tale extends BaseDocument {
   title: string;
   updated: Date;
   workspaceId: string;
-  workspaceModified: number;
 
   // currently unused by frontend
   _modelType: string;


### PR DESCRIPTION
See https://github.com/whole-tale/gwvolman/pull/123 for primary change and test case.

The workspaceModified field is no longer needed/used with the move to virtual resources. This field appears to be unused by the UI but present in the tale model definition.