### PR TITLE
fix: open User Guide in a new tab

### DIFF
--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,7 +5,7 @@
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
-      <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/">
+      <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/" target="_blank">
         <i class="info circle white icon"></i>
       </a>
       <a class="item" (click)="toggleNotificationStream()">


### PR DESCRIPTION
## Problem
User Guide does not open in a new tab. This disrupts user workflow if they click the button, regardless of whether the click was intentional or accidental.

## Approach
Open User Guide in a new tab.
 
## How to Test 
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Click ( i ) at the top-right of the navbar
    * User Guide should open in a new tab
