### PR TITLE
fix: correct all linting warnings

### DIFF
--- a/src/app/+run-tale/run-tale.module.ts
+++ b/src/app/+run-tale/run-tale.module.ts
@@ -14,19 +14,19 @@ import { TalesModule } from '@tales/tales.module';
 import { MarkdownModule } from 'ngx-markdown';
 
 import { routes } from './run-tale.routes';
-import { TaleVersionInfoDialogComponent } from './run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component';
+import { ConnectGitRepoDialogComponent } from './run-tale/modals/connect-git-repo-dialog/connect-git-repo-dialog.component';
 import { CreateRenameVersionDialogComponent } from './run-tale/modals/create-rename-version-dialog/create-rename-version-dialog.component';
 import { PublishTaleDialogComponent } from './run-tale/modals/publish-tale-dialog/publish-tale-dialog.component';
 import { RegisterDataDialogComponent } from './run-tale/modals/register-data-dialog/register-data-dialog.component';
-import { ConnectGitRepoDialogComponent } from './run-tale/modals/connect-git-repo-dialog/connect-git-repo-dialog.component';
 import { SelectDataDialogComponent } from './run-tale/modals/select-data-dialog/select-data-dialog.component';
+import { TaleVersionInfoDialogComponent } from './run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component';
 import { TaleWorkspacesDialogComponent } from './run-tale/modals/tale-workspaces-dialog/tale-workspaces-dialog.component';
 import { RunTaleComponent } from './run-tale/run-tale.component';
 import { TaleFilesComponent } from './run-tale/tale-files/tale-files.component';
 import { TaleInteractComponent } from './run-tale/tale-interact/tale-interact.component';
 import { TaleMetadataComponent } from './run-tale/tale-metadata/tale-metadata.component';
-import { TaleVersionsPanelComponent } from './run-tale/tale-versions-panel/tale-versions-panel.component';
 import { TaleSharingComponent } from './run-tale/tale-sharing/tale-sharing.component';
+import { TaleVersionsPanelComponent } from './run-tale/tale-versions-panel/tale-versions-panel.component';
 
 
 @NgModule({

--- a/src/app/+run-tale/run-tale/modals/create-rename-version-dialog/create-rename-version-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/create-rename-version-dialog/create-rename-version-dialog.component.ts
@@ -2,8 +2,8 @@ import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Tale } from '@api/models/tale';
 import { RepositoryService } from '@api/services/repository.service';
-import { LogService }  from '@framework/core/log.service';
 import { VersionService } from '@api/services/version.service';
+import { LogService }  from '@framework/core/log.service';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 

--- a/src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.ts
@@ -60,6 +60,7 @@ export class PublishTaleDialogComponent implements OnInit {
       const dateB = Date.parse(b.date);
       if (dateA > dateB) { return 1; }
       if (dateA < dateB) { return -1; }
+
       return 0;
     }).slice(-1).pop();
   }

--- a/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
@@ -65,10 +65,9 @@ export class SelectDataDialogComponent implements OnInit {
     this.allDatasets = this.datasetService.datasetListDatasets({ myData: false });
     this.datasets = this.myDatasets = this.datasetService.datasetListDatasets({ myData: true });
 
-    let preAddedDatasets = this.data.tale.dataSet.map((ds: { itemId: string, mountPath: string, _modelType: string }) => {
+    const preAddedDatasets = this.data.tale.dataSet.map((ds: { itemId: string, mountPath: string, _modelType: string }) =>
       // Lookup the Dataset by id and push it to our selection
-      return { _modelType: ds._modelType, _id: ds.itemId, name: ds.mountPath };
-    });
+      ({ _modelType: ds._modelType, _id: ds.itemId, name: ds.mountPath }));
 
     this.addedDatasets.next(preAddedDatasets);
   }

--- a/src/app/+run-tale/run-tale/modals/tale-workspaces-dialog/tale-workspaces-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/tale-workspaces-dialog/tale-workspaces-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, NgZone, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 // import { Workspace } from '@api/models/workspace';   // TODO: Missing model
 // import { WorkspaceService } from '@api/services/workspace.service';
+import { AccessLevel } from '@api/models/access-level';
 import { Tale } from '@api/models/tale';
 import { FolderService } from '@api/services/folder.service';
 import { ItemService } from '@api/services/item.service';
@@ -12,7 +13,6 @@ import { LogService }  from '@framework/core/log.service';
 import { TruncatePipe } from '@framework/core/truncate.pipe';
 import { enterZone }  from '@framework/ngrx';
 import { BehaviorSubject } from 'rxjs';
-import { AccessLevel } from '@api/models/access-level';
 
 enum ParentType {
     Folder = "folder",

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -33,9 +33,6 @@ app-tale-versions-panel {
   //position: absolute;
   right: 0;
   height: 100%;
-  height: fill-available;
-  height: -moz-fill-available;
-  height: -webkit-fill-available;
 }
 
 .lighter {

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectorRef, Component, NgZone, OnChanges, OnInit } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ApiConfiguration } from '@api/api-configuration';
+import { AccessLevel } from '@api/models/access-level';
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
@@ -8,18 +10,16 @@ import { InstanceService } from '@api/services/instance.service';
 import { TaleService } from '@api/services/tale.service';
 import { UserService } from '@api/services/user.service';
 import { VersionService } from '@api/services/version.service';
+import { TokenService } from '@api/token.service';
 import { BaseComponent } from '@framework/core';
 import { LogService } from '@framework/core/log.service';
 import { WindowService } from '@framework/core/window.service';
 import { enterZone } from '@framework/ngrx/enter-zone.operator';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { routeAnimation } from '~/app/shared';
-import { AccessLevel } from '@api/models/access-level';
 
-import { ApiConfiguration } from '@api/api-configuration';
-import { TokenService } from '@api/token.service';
-import { PublishTaleDialogComponent } from './modals/publish-tale-dialog/publish-tale-dialog.component';
 import { ConnectGitRepoDialogComponent } from './modals/connect-git-repo-dialog/connect-git-repo-dialog.component';
+import { PublishTaleDialogComponent } from './modals/publish-tale-dialog/publish-tale-dialog.component';
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -44,10 +44,6 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     currentTab = 'metadata';
     showVersionsPanel = false;
 
-    isVersionsPanelShown() :boolean {
-      return this.showVersionsPanel;
-    }
-
     collaborators: { users: Array<User>, groups: Array<User> } = { users: [], groups: [] };
 
     constructor(
@@ -68,6 +64,10 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         super();
     }
 
+    isVersionsPanelShown() :boolean {
+      return this.showVersionsPanel;
+    }
+
     trackByAuthorOrcid(index: number, author: TaleAuthor): string {
         return author.orcid;
     }
@@ -86,11 +86,11 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     }
 
     get dashboardLink(): string {
-      if (!this.tale || this.tale._accessLevel == AccessLevel.None) {
+      if (!this.tale || this.tale._accessLevel === AccessLevel.None) {
         return '/public';
-      } else if (this.tale._accessLevel == AccessLevel.Admin) {
+      } else if (this.tale._accessLevel === AccessLevel.Admin) {
         return '/mine';
-      } else if (this.tale._accessLevel == AccessLevel.Read || this.tale._accessLevel == AccessLevel.Write) {
+      } else if (this.tale._accessLevel === AccessLevel.Read || this.tale._accessLevel === AccessLevel.Write) {
         return '/shared';
       }
     }
@@ -116,13 +116,11 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       return this.currentTab === tab;
     }
 
-    refreshCollaborators() {
+    refreshCollaborators(): void {
       this.taleService.taleGetTaleAccess(this.taleId).subscribe(resp => {
-        //this.zone.run(() => {
-          this.logger.info("Fetched collaborators:", resp);
-          this.collaborators = resp;
-          this.ref.detectChanges();
-        //});
+        this.logger.info("Fetched collaborators:", resp);
+        this.collaborators = resp;
+        this.ref.detectChanges();
       });
     }
 
@@ -192,18 +190,18 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.detectCurrentTab();
     }
 
-    performRecordedRun() {
-      console.log('Performing recorded run');
+    performRecordedRun(): void {
+      this.logger.debug('Performing recorded run');
     }
 
-    saveTaleVersion() {
-      console.log('Saving Tale version');
+    saveTaleVersion(): void {
+      this.logger.debug('Saving Tale version');
       this.versionService.versionCreateVersion({ taleId: this.taleId, force: true }).subscribe(version => {
-        console.log("Version saved successfully:", version);
+        this.logger.debug("Version saved successfully:", version);
       });
     }
 
-    openConnectGitRepoDialog() {
+    openConnectGitRepoDialog(): void {
       const config: MatDialogConfig = {
         data: { tale: this.tale }
       };

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -15,7 +15,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Authors</label>
           <div class="thirteen wide column" style="padding-left:0;">
-            <h4 style="text-align: center">Created by <span style="color:#67c096">{{creator.firstName}} {{creator.lastName}}</span></h4>
+            <h4 style="text-align: center">Created by <span style="color:#67c096">{{ creator.firstName }} {{ creator.lastName }}</span></h4>
 
             <form id="taleAuthorsSubForm" #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="tale.authors.length">
               <table class="ui table striped condensed">

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -1,22 +1,20 @@
 import { ChangeDetectorRef, Component, Input, NgZone, OnInit } from '@angular/core';
 import { ApiConfiguration } from '@api/api-configuration';
+import { AccessLevel } from '@api/models/access-level';
 import { Image } from '@api/models/image';
 import { License } from '@api/models/license';
-import { Tale } from '@api/models/tale';
 import { PublishInfo } from '@api/models/publish-info';
+import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
 import { ImageService } from '@api/services/image.service';
 import { LicenseService } from '@api/services/license.service';
 import { TaleService } from '@api/services/tale.service';
 import { LogService } from '@framework/core/log.service';
 import { enterZone } from '@framework/ngrx/enter-zone.operator';
-import { NotificationService } from '@shared/error-handler/services/notification.service';
 import { ErrorService } from '@shared/error-handler/services/error.service';
+import { NotificationService } from '@shared/error-handler/services/notification.service';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { Observable } from 'rxjs';
-
-import { AccessLevel } from '@api/models/access-level';
-
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -48,6 +46,7 @@ export class TaleMetadataComponent implements OnInit {
     if (!this.tale) {
       return false;
     }
+
     return this.tale._accessLevel >= AccessLevel.Write;
   }
 
@@ -64,6 +63,7 @@ export class TaleMetadataComponent implements OnInit {
       const dateB = Date.parse(b.date);
       if (dateA > dateB) { return 1; }
       if (dateA < dateB) { return -1; }
+
       return 0;
     }).slice(-1).pop();
   }
@@ -95,15 +95,15 @@ export class TaleMetadataComponent implements OnInit {
     // TODO: Revert to last known _previousState
     // TODO: Ask for confirmation, if yes then
     this.tale = this.copy(this._previousState);
-    // and then
+
     return true;
   }
 
-  scrollToTop() {
-      this.zone.runOutsideAngular(() => {
-        // Edge case: Scroll to top of view
-        document.querySelector('#scrollContainer').scrollTop = 0;
-      });
+  scrollToTop(): void {
+    this.zone.runOutsideAngular(() => {
+      // Edge case: Scroll to top of view
+      document.querySelector('#scrollContainer').scrollTop = 0;
+    });
   }
 
   startEdit(): void {
@@ -163,18 +163,20 @@ export class TaleMetadataComponent implements OnInit {
     return index;
   }
 
-  transformIdentifier(identifier: string) {
+  transformIdentifier(identifier: string): string {
     if (identifier.indexOf('doi:') === 0) {
       return identifier.replace('doi:', 'doi.org/');
     }
+
     return identifier;
   }
 
   updateTale(): Promise<any> {
     const errors = this.validateAuthors();
     if (errors && errors.length > 0) {
-      this.notificationService.showError('Failed to save: ' + errors[0].message);
-      return new Promise(() => {});
+      this.notificationService.showError(`Failed to save: ${errors[0].message}`);
+
+      return new Promise(() => { this.logger.debug('Noop') });
     }
 
     const params = { id: this.tale._id , tale: this.tale };
@@ -188,6 +190,7 @@ export class TaleMetadataComponent implements OnInit {
     }, err => {
       this.logger.error("Failed updating tale:", err);
     });
+
     return promise;
   }
 

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -55,7 +55,7 @@
           </div>
         </div>
         <div class="content">
-          <div class="date">{{ version.updated | date:'short'}}</div>
+          <div class="date">{{ version.updated | date:'short' }}</div>
           <div class="header"><i class="fas fa-save"></i>Version saved:</div>
           {{ version.name }}
         </div>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -4,9 +4,9 @@ import { Tale } from '@api/models/tale';
 import { Version } from '@api/models/version';
 import { TaleService } from '@api/services/tale.service';
 import { VersionService } from '@api/services/version.service';
-import { NotificationService } from '@shared/error-handler/services/notification.service';
 import { LogService } from '@framework/core/log.service';
 import { enterZone } from '@framework/ngrx/enter-zone.operator';
+import { NotificationService } from '@shared/error-handler/services/notification.service';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { Observable } from 'rxjs';
 
@@ -100,7 +100,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges {
     });
   }
 
-  openCreateRenameModal(mode: string = "create", after: Function): void {
+  openCreateRenameModal(mode = "create", after: Function): void {
       const config = { data: { taleId: this.tale._id, mode } };
       const dialogRef = this.dialog.open(CreateRenameVersionDialogComponent, config);
       dialogRef.afterClosed().subscribe((result: { name: string, force?: boolean }) => {
@@ -151,7 +151,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges {
     });
   }
 
-  deleteVersion(version: Version) {
+  deleteVersion(version: Version): void {
     // Delete the chosen version
     this.versionService.versionDeleteVersion(version._id).subscribe(response => {
       this.logger.info("Tale version successfully deleted:", version.name);

--- a/src/app/+tale-catalog/tale-catalog.module.ts
+++ b/src/app/+tale-catalog/tale-catalog.module.ts
@@ -17,9 +17,9 @@ import { DeleteTaleModalComponent } from './tale-catalog/modals/delete-tale-moda
 import { MyTalesPipe } from './tale-catalog/pipes/my-tales.pipe';
 import { PublicTalesPipe } from './tale-catalog/pipes/public-tales.pipe';
 import { RunningTalesPipe } from './tale-catalog/pipes/running-tales.pipe';
-import { StoppedTalesPipe } from './tale-catalog/pipes/stopped-tales.pipe';
 import { SearchTalesPipe } from './tale-catalog/pipes/search-tales.pipe';
 import { SharedTalesPipe } from './tale-catalog/pipes/shared-tales.pipe';
+import { StoppedTalesPipe } from './tale-catalog/pipes/stopped-tales.pipe';
 import { TaleCatalogComponent } from './tale-catalog/tale-catalog.component';
 
 @NgModule({

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectorRef, Component, Input, NgZone, OnChanges, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { AccessLevel } from '@api/models/access-level';
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
@@ -11,7 +12,6 @@ import { LogService } from '@framework/core/log.service';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { Observable, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { AccessLevel } from '@api/models/access-level';
 
 import { DeleteTaleModalComponent } from '../../modals/delete-tale-modal/delete-tale-modal.component';
 

--- a/src/app/+tale-catalog/tale-catalog/components/running-tales/running-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/running-tales/running-tales.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, NgZone } from '@angular/core';
+import { Component, Input, NgZone, Output } from '@angular/core';
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
@@ -15,14 +15,11 @@ declare var $: any;
 })
 export class RunningTalesComponent {
 
-  @Input()
-  taleList: Array<Tale>;
+  @Input() taleList: Array<Tale>;
 
-  @Input()
-  instances: Map<string, Instance>; // = new Map<string, Instance> ();
+  @Input() instances: Map<string, Instance>; // = new Map<string, Instance> ();
 
-  @Input()
-  creators: Map<string, Instance>; // = new Map<string, Instance> ();
+  @Input() creators: Map<string, Instance>; // = new Map<string, Instance> ();
 
   constructor(private readonly zone: NgZone) {  }
 
@@ -44,6 +41,6 @@ export class RunningTalesComponent {
   }
 
   taleInstanceStateChanged(updated: {tale: Tale, instance: Instance}): void {
-    //this.refresh();
+    // this.refresh();
   }
 }

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -3,6 +3,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { Image } from '@api/models/image';
 import { Tale } from '@api/models/tale';
 import { ImageService } from '@api/services/image.service';
+import { LogService } from '@framework/core/log.service';
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -14,14 +15,20 @@ declare var $: any;
 export class CreateTaleModalComponent implements OnInit,AfterViewInit {
   newTale: Tale;
   datasetCitation: any;
-  asTale: boolean = false;
+  asTale = false;
   gitUrl = '';
 
   showGit = false;
 
   environments: Array<Image> = [];
 
-  constructor(private zone: NgZone, public dialogRef: MatDialogRef<CreateTaleModalComponent>, @Inject(MAT_DIALOG_DATA) public data: { params: any, showGit: boolean }, private imageService: ImageService) {
+  constructor(
+      private zone: NgZone,
+      public dialogRef: MatDialogRef<CreateTaleModalComponent>,
+      @Inject(MAT_DIALOG_DATA) public data: { params: any, showGit: boolean },
+      private imageService: ImageService,
+      private logger: LogService
+    ) {
     this.newTale = {
       title: (data && data.params) ? data.params.name : '',
       imageId: '',
@@ -31,7 +38,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       publishInfo: [],
       dataSet: [],
       public: false,
-      copyOfTale: null,
+      copyOfTale: undefined,
       description: '### Provide a description for your Tale'
     };
     this.showGit = data.showGit;
@@ -87,17 +94,17 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
             // If found, select it in the dropdown
             this.newTale.imageId = match._id;
           } else {
-            console.error(`Failed to find an environment named ${this.data.params.environment}`);
+            this.logger.error(`Failed to find an environment named ${this.data.params.environment}`);
           }
         }
       });
     }, err => {
-      console.error("Failed to list images:", err);
+      this.logger.error("Failed to list images:", err);
     });
   }
 
   enableReadOnly(evt: any): void {
-    console.log("Enabling read only on this Tale...");
+    this.logger.info("Enabling read only on this Tale...");
     const target = evt.target;
     if (target.checked) {
       this.asTale = false;
@@ -105,7 +112,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
   }
 
   enableReadWrite(evt: any): void {
-    console.log("Enabling read/write on this Tale...");
+    this.logger.info("Enabling read/write on this Tale...");
     const target = evt.target;
     if (target.checked) {
       this.asTale = true;

--- a/src/app/+tale-catalog/tale-catalog/pipes/my-tales.pipe.ts
+++ b/src/app/+tale-catalog/tale-catalog/pipes/my-tales.pipe.ts
@@ -1,17 +1,16 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Tale } from '@api/models/tale';
 import { AccessLevel } from '@api/models/access-level';
+import { Tale } from '@api/models/tale';
 
 // Given a list of tales, returns only tales that were created by the current user
 @Pipe({name: 'myTales'})
 export class MyTalesPipe implements PipeTransform {
-  constructor() {  }
 
   transform(value: Array<Tale>): Array<Tale> {
     if (!value || !value.length) {
       return [];
     }
 
-    return value.filter(tale => tale._accessLevel == AccessLevel.Admin);
+    return value.filter(tale => tale._accessLevel === AccessLevel.Admin);
   }
 }

--- a/src/app/+tale-catalog/tale-catalog/pipes/public-tales.pipe.ts
+++ b/src/app/+tale-catalog/tale-catalog/pipes/public-tales.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Tale } from '@api/models/tale';
 import { AccessLevel } from '@api/models/access-level';
+import { Tale } from '@api/models/tale';
 
 // Given a list of tales, returns only public tales
 @Pipe({name: 'publicTales'})
@@ -10,6 +10,6 @@ export class PublicTalesPipe implements PipeTransform {
       return [];
     }
 
-    return value.filter(tale => tale._accessLevel == AccessLevel.None || tale.public);
+    return value.filter(tale => tale._accessLevel === AccessLevel.None || tale.public);
   }
 }

--- a/src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
+++ b/src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
@@ -1,10 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
-import { TaleAuthor } from '@tales/models/tale-author';
 import { TokenService } from '@api/token.service';
-
 import { LogService } from '@framework/core/log.service';
+import { TaleAuthor } from '@tales/models/tale-author';
 
 // Given a list of tales, returns only tales that were created by the current user
 @Pipe({name: 'searchTales'})

--- a/src/app/+tale-catalog/tale-catalog/pipes/shared-tales.pipe.ts
+++ b/src/app/+tale-catalog/tale-catalog/pipes/shared-tales.pipe.ts
@@ -1,19 +1,16 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Tale } from '@api/models/tale';
 import { AccessLevel } from '@api/models/access-level';
+import { Tale } from '@api/models/tale';
 
 // Given a list of tales, returns only stopped tales
 @Pipe({name: 'sharedTales'})
 export class SharedTalesPipe implements PipeTransform {
-  constructor() {  }
 
   transform(value: Array<Tale>): Array<Tale> {
     if (!value) {
       return [];
     }
 
-    return value.filter(tale => {
-      return tale._accessLevel == AccessLevel.Read || tale._accessLevel == AccessLevel.Write;
-    });
+    return value.filter(tale => (tale._accessLevel === AccessLevel.Read || tale._accessLevel === AccessLevel.Write));
   }
 }

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -57,7 +57,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
               const tale = result.tale;
               const asTale = result.asTale;
 
-              // Short-circuit for 'Cancel' case
+              // Short-circuit for 'Cancel' case
               if (!tale) { return; }
 
               // Import Tale from Dataset
@@ -67,8 +67,8 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
                 asTale: asTale ? asTale : false, // Pull from user input
                 git: result.url ? true : false,
                 spawn: true, // if true, immediately launch a Tale instance
-                taleKwargs: tale.title ? { title: tale.title } : {}, // ??
-                lookupKwargs: {}, // ??
+                taleKwargs: tale.title ? { title: tale.title } : {}, 
+                lookupKwargs: {},
               };
               this.taleService.taleCreateTaleFromUrl(params).subscribe(resp => {
                 this.logger.debug("Successfully submitted 'Analyze in WT' Job:", resp);
@@ -103,8 +103,8 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
             asTale: false, // Pull from user input
             git: gitUrl ? true : false,
             spawn: false, // if true, immediately launch a Tale instance
-            taleKwargs: tale.title ? { title: tale.title } : {}, // ??
-            lookupKwargs: {}, // ??
+            taleKwargs: tale.title ? { title: tale.title } : {},
+            lookupKwargs: {},
           };
 
           this.taleService.taleCreateTaleFromUrl(params).subscribe((response: Tale) => {

--- a/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
+++ b/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit, NgZone } from '@angular/core';
+import { Component, Inject, NgZone, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Account } from '@api/models/account';
 import { User } from '@api/models/user';
@@ -59,7 +59,7 @@ export class ConnectApiKeyModalComponent extends BaseComponent implements OnInit
       });
   }
 
-  onTargetChange(value: any, text: string, $choice: any) {
+  onTargetChange(value: any, text: string, $choice: any): void {
       this.newApiKey.resource_server = value;
   }
 

--- a/src/app/api/auth-guard.ts
+++ b/src/app/api/auth-guard.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateChild, Router, RouterStateSnapshot } from '@angular/router';
-
 import { User } from '@api/models/user';
 import { UserService } from '@api/services/user.service';
 import { TokenService } from '@api/token.service';
@@ -9,7 +8,7 @@ import { TokenService } from '@api/token.service';
 export class AuthGuard implements CanActivateChild {
   constructor(private readonly router: Router, private readonly userService: UserService, private readonly tokenService: TokenService) {}
 
-  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+  canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       this.userService.userGetMe().subscribe(
         (user: User) => {
@@ -24,6 +23,7 @@ export class AuthGuard implements CanActivateChild {
           }
 
           this.router.navigate(['login'], { queryParams: { rd: url } });
+
           return resolve(false);
         },
         () => resolve(false)

--- a/src/app/api/token.service.ts
+++ b/src/app/api/token.service.ts
@@ -28,7 +28,7 @@ export class TokenService {
   clearToken(): void {
     localStorage.removeItem('girderToken');
   }
-  setReturnRoute(returnRoute: string) {
+  setReturnRoute(returnRoute: string): void {
     localStorage.setItem('returnRoute', returnRoute);
   }
   getReturnRoute(): string {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,9 +27,8 @@ import { routes } from './app.routes';
 import { FooterComponent } from './layout/footer.component';
 import { HeaderComponent } from './layout/header.component';
 import { MainComponent } from './layout/main.component';
-import { LoginComponent } from './login/login.component';
-
 import { NotificationStreamModule } from './layout/notification-stream/notification-stream.module';
+import { LoginComponent } from './login/login.component';
 
 export const REQ_KEY = makeStateKey<string>('req');
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -42,7 +42,7 @@ export const routes = [
         loadChildren: './+user-settings/user-settings.module#UserSettingsModule'
       }
     ],
-    canActivateChild: [MetaGuard, CustomAuthGuard /*, AuthGuard */],
+    canActivateChild: [MetaGuard, CustomAuthGuard], // AuthGuard
     data: {
       i18n: {
         isRoot: true

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
@@ -60,6 +60,7 @@ export class MoveToDialogComponent implements OnInit {
     if (!lastItem) {
       return undefined;
     }
+
     return lastItem._id;
   }
 
@@ -70,6 +71,7 @@ export class MoveToDialogComponent implements OnInit {
 
     const lastIndex = this.pathStack.length - 1;
     const lastItem = this.pathStack[lastIndex];
+
     return lastItem;
   }
 
@@ -85,6 +87,7 @@ export class MoveToDialogComponent implements OnInit {
           // Fetch Tale via ID, then display its title
           return (async () => {
             const taleId = e.name;
+
             return this.taleNamePipe.transform(taleId).toPromise();
           })();
         } else {
@@ -179,6 +182,7 @@ export class MoveToDialogComponent implements OnInit {
   navigate(elem: FileElement): void {
     if (!elem || elem._modelType !== 'folder') {
       this.logger.warn('Attempted to navigate into a non-folder: ', elem);
+
       return;
     }
 
@@ -191,6 +195,7 @@ export class MoveToDialogComponent implements OnInit {
   navigateUp(): void {
     if (!this.pathStack.length) {
       this.logger.warn('Attempted to pop from empty path: ', this.pathStack);
+
       return;
     }
 
@@ -200,12 +205,14 @@ export class MoveToDialogComponent implements OnInit {
   }
 
   // Select folder
-  selectFolder(elem: FileElement) {
+  selectFolder(elem: FileElement): void {
     if (!elem || elem._modelType !== 'folder') {
       this.logger.warn('Attempted to select a non-folder: ', elem);
+
       return;
     } else if (elem._id === this.data.elementToMove._id) {
       this.logger.warn('Attempted to move the current item into itself: ', elem);
+
       return;
     }
     this.selectedFolder = elem;

--- a/src/app/framework/core/window.service.ts
+++ b/src/app/framework/core/window.service.ts
@@ -4,7 +4,7 @@ export class WindowService implements Window {
   navigator: any = {};
   location: any = {};
 
-  open(url: string, target?: string) {
+  open(url: string, target?: string): void {
     return;
   }
 

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -35,7 +35,7 @@ export class HeaderComponent extends BaseComponent implements OnInit {
 
   // events: Array<EventData>;
 
-  @Output() toggledNotificationStream: EventEmitter<Boolean> = new EventEmitter<Boolean>();
+  @Output() readonly toggledNotificationStream: EventEmitter<Boolean> = new EventEmitter<Boolean>();
 
   constructor(
     private readonly zone: NgZone,
@@ -100,6 +100,7 @@ export class HeaderComponent extends BaseComponent implements OnInit {
     if (!this.events) {
       return 0;
     }
+
     return this.events.length;
   }
 }

--- a/src/app/layout/main.component.ts
+++ b/src/app/layout/main.component.ts
@@ -16,7 +16,7 @@ export class MainComponent extends BaseComponent {
     super();
 
     router.events.subscribe(val => {
-      if (location.path() != '') {
+      if (location.path() !== '') {
         this.route = location.path();
       }
     });

--- a/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
+++ b/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
@@ -39,34 +39,36 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
     this.autoFetch(latestJob);
   }
 
-  mergeLogs() {
+  mergeLogs(): void {
     let logs = '';
 
     // Sort jobs by date/time
-    this.jobs.sort((a: Job, b: Job) => {
-      if (a.created > b.created) {
-        return 1;
+    this.jobs.sort(
+      (a: Job, b: Job): number => {
+        if (a.created > b.created) {
+          return 1;
+        }
+        if (a.created < b.created) {
+          return -1;
+        }
+
+        return 0;
       }
-      if (a.created < b.created) {
-        return -1;
-      }
-      return 0;
-    });
+    );
 
     // Concatenate all logs together for display
     this.jobs.forEach((job: Job) => {
-      logs += job.log.join('') + '\n\n\n\n\n';
+      logs += `${job.log.join('')}\n\n\n\n\n`;
     });
 
     this.logs.next(logs);
     this.ref.detectChanges();
   }
 
-  stopPolling(interval: any) {
+  stopPolling(interval: any): void {
     if (interval) {
       this.intervals.splice(this.intervals.indexOf(interval), 1);
       clearInterval(interval);
-      interval = undefined;
     }
   }
 
@@ -91,7 +93,7 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
     this.intervals.push(interval);
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.intervals.forEach((interval: any) => {
       this.stopPolling(interval);
     });

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -45,6 +45,7 @@ export class NotificationStreamComponent {
     if (!this.events) {
       return 0;
     }
+
     return this.events.length;
   }
 
@@ -52,7 +53,7 @@ export class NotificationStreamComponent {
     return this.notificationStream.showNotificationStream;
   }
 
-  ackAll() {
+  ackAll(): void {
     this.zone.run(() => {
       this.notificationStream.ackAll();
       this.ref.detectChanges();
@@ -104,6 +105,7 @@ export class NotificationStreamComponent {
   openLogViewerModal(event: EventData): void {
     if (!event || !event.data || !event.data.resource || !event.data.resource.jobs || !event.data.resource.jobs.length) {
       this.logger.error('Failed to view logs - no jobId provided by event.');
+
       return;
     }
 

--- a/src/app/layout/notification-stream/notification-stream.module.ts
+++ b/src/app/layout/notification-stream/notification-stream.module.ts
@@ -5,10 +5,9 @@ import { SharedModule } from '@framework/core';
 import { MaterialModule } from '@framework/material';
 import { TalesService } from '@tales/tales.service';
 
-import { NotificationStreamService } from './notification-stream.service';
-
 import { ViewLogsDialogComponent } from './modals/view-logs-dialog/view-logs-dialog.component';
 import { NotificationStreamComponent } from './notification-stream.component';
+import { NotificationStreamService } from './notification-stream.service';
 
 @NgModule({
   declarations: [NotificationStreamComponent, ViewLogsDialogComponent],

--- a/src/app/shared/common/common.module.ts
+++ b/src/app/shared/common/common.module.ts
@@ -1,12 +1,11 @@
 import { CommonModule as CommonAngularModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MaterialModule } from '~/app/framework/material';
+import { MaterialModule } from '@framework/material';
 
 import { LoadingOverlayComponent } from './components/loading-overlay/loading-overlay.component';
 import { MenuGroupComponent } from './components/menu/menu-group.component';
 import { MenuItemComponent } from './components/menu/menu-item.component';
-
 import { TruncatePipe } from './pipes/truncate.pipe';
 
 const COMPONENTS = [LoadingOverlayComponent, MenuGroupComponent, MenuItemComponent];

--- a/src/app/shared/common/pipes/truncate.pipe.ts
+++ b/src/app/shared/common/pipes/truncate.pipe.ts
@@ -3,8 +3,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 // Given a string, truncate it to the provided maximum length
 @Pipe({ name: 'truncate' })
 export class TruncatePipe implements PipeTransform {
-  constructor() {}
-
   transform(value: string, maxLength = 35): string {
     if (!value) {
       return '';

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -57,6 +57,7 @@ export class TaleRunButtonComponent implements OnChanges {
     this.interval = setInterval(() => {
       if (!this.instance || !this.instance._id) {
         stopPolling();
+
         return;
       }
 
@@ -163,7 +164,7 @@ export class TaleRunButtonComponent implements OnChanges {
           // this.refresh();
           // this.startTale(taleCopy);
           // Update the display with the newly-created Tale copy
-          this.taleInstanceStateChanged.emit({ tale: taleCopy, instance: null });
+          this.taleInstanceStateChanged.emit({ tale: taleCopy, instance: undefined });
 
           // Navigate the UI to the new Tale copy
           this.router.navigate(['run', taleCopy._id]);

--- a/src/app/tales/tales.module.ts
+++ b/src/app/tales/tales.module.ts
@@ -7,7 +7,6 @@ import { TalesService } from '@tales/tales.service';
 
 import { CopyOnLaunchModalComponent } from './components/modals/copy-on-launch-modal/copy-on-launch-modal.component';
 import { TaleRunButtonComponent } from './components/tale-run-button/tale-run-button.component';
-
 import { TaleCreatorPipe } from './pipes/tale-creator.pipe';
 import { TaleImagePipe } from './pipes/tale-image.pipe';
 import { TaleNamePipe } from './pipes/tale-name.pipe';


### PR DESCRIPTION
## Problem
Cleaning up the linting warnings from the mass development over the past several months.

## Approach
Systematic.

### Full Listing of Warnings
```javascript
ℹ ｢wdm｣: Compiling...
                                                                                                      a Date: 2021-01-12T19:53:26.288Z - Hash: a47dd49e19dcdd3c6f97 - Time: 4531ms
11 unchanged chunks
chunk {styles} styles.js, styles.js.map (styles) 2.27 MB [initial] [rendered]

WARNING in ./src/app/+run-tale/run-tale/run-tale.component.scss
Module Warning (from ./node_modules/postcss-loader/src/index.js):
Warning

(31:3) Replace fill-available to stretch, because spec had been changed

WARNING in ./src/app/+tale-catalog/tale-catalog/components/running-tales/running-tales.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[1, 28]: Named imports must be alphabetized.
[47, 7]: comment must start with a space
[18, 3]: Consider placing decorators on the same line as the property/method it decorates
[21, 3]: Consider placing decorators on the same line as the property/method it decorates
[24, 3]: Consider placing decorators on the same line as the property/method it decorates


WARNING in ./src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[1, 29]: Named imports must be alphabetized.
[62, 3]: expected call-signature: 'onTargetChange' to have a typedef


WARNING in ./src/app/shared/common/common.module.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[10, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.


WARNING in ./src/app/layout/notification-stream/notification-stream.module.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[10, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.


WARNING in ./src/app/layout/header.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[103, 5]: Missing blank line before return
[38, 13]: Prefer to declare `@Output` as readonly since they are not supposed to be reassigned


WARNING in ./src/app/tales/tales.module.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[11, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.


WARNING in ./src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[119, 11]: Assigning `this` reference to local variable not allowed: self.
[165, 17]: non-arrow functions are forbidden
[313, 9]: Identifier 'promise' is never reassigned; use 'const' instead of 'let'.
[53, 3]: expected call-signature: 'handleChange' to have a typedef
[84, 3]: expected call-signature: 'getDisplayedCollaborators' to have a typedef
[165, 25]: expected call-signature to have a typedef
[232, 3]: expected call-signature: 'initializeDropdown' to have a typedef
[245, 3]: expected call-signature: 'addCollaborator' to have a typedef
[273, 3]: expected call-signature: 'removeCollaborator' to have a typedef
[327, 3]: expected call-signature: 'clearNewCollaborator' to have a typedef
[330, 26]: Use 'undefined' instead of 'null'
[165, 7]: Expected method shorthand in object literal ('{onSelect() {...}}').
[66, 25]: Use a template literal instead of concatenating with a string literal.
[106, 85]: == should be ===
[294, 77]: == should be ===
[100, 5]: Missing blank line before return
[148, 11]: Missing blank line before return
[176, 9]: Missing blank line before return
[319, 5]: Missing blank line before return
[133, 13]: comment must start with a space
[170, 11]: comment must start with a space
[44, 13]: Prefer to declare `@Output` as readonly since they are not supposed to be reassigned


WARNING in ./src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[14, 1]: Import sources within a group must be alphabetized.


WARNING in ./src/app/+run-tale/run-tale/modals/tale-workspaces-dialog/tale-workspaces-dialog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[15, 1]: Import sources within a group must be alphabetized.


WARNING in ./src/app/tales/components/tale-run-button/tale-run-button.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[166, 74]: Use 'undefined' instead of 'null'
[60, 9]: Missing blank line before return


WARNING in ./src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[17, 11]: Type boolean trivially inferred from a boolean literal, remove type annotation
[34, 19]: Use 'undefined' instead of 'null'
[100, 5]: Calls to 'console.log' are not allowed.
[108, 5]: Calls to 'console.log' are not allowed.


WARNING in ./src/app/+run-tale/run-tale.module.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[18, 1]: Import sources within a group must be alphabetized.
[21, 1]: Import sources within a group must be alphabetized.
[29, 1]: Import sources within a group must be alphabetized.


WARNING in ./src/app/layout/main.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[19, 27]: != should be !==


WARNING in ./src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[203, 3]: expected call-signature: 'selectFolder' to have a typedef
[63, 5]: Missing blank line before return
[73, 5]: Missing blank line before return
[88, 13]: Missing blank line before return
[182, 7]: Missing blank line before return
[194, 7]: Missing blank line before return
[206, 7]: Missing blank line before return
[209, 7]: Missing blank line before return


WARNING in ./src/app/+tale-catalog/tale-catalog.module.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[21, 1]: Import sources within a group must be alphabetized.


WARNING in ./src/app/+tale-catalog/tale-catalog/pipes/public-tales.pipe.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[3, 1]: Import sources within a group must be alphabetized.
[13, 51]: == should be ===


WARNING in ./src/app/api/token.service.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[31, 3]: expected call-signature: 'setReturnRoute' to have a typedef


WARNING in ./src/app/app.module.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[32, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.


WARNING in ./src/app/api/auth-guard.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[4, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.
[12, 3]: expected call-signature: 'canActivateChild' to have a typedef
[27, 11]: Missing blank line before return


WARNING in ./src/app/app.routes.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[45, 51]: multiline comments are not allowed


WARNING in ./src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[5, 1]: Import sources within a group must be alphabetized.
[7, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.


WARNING in ./src/app/+run-tale/run-tale/run-tale.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[51, 5]: Declaration of public instance field not allowed after declaration of public instance method. Instead, this should come at the beginning of the class/interface.
[17, 1]: Import sources within a group must be alphabetized.
[22, 1]: Import sources within a group must be alphabetized.
[19, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.
[21, 1]: Import sources of different groups must be sorted by: libraries, parent directories, current directory.
[119, 5]: expected call-signature: 'refreshCollaborators' to have a typedef
[195, 5]: expected call-signature: 'performRecordedRun' to have a typedef
[199, 5]: expected call-signature: 'saveTaleVersion' to have a typedef
[206, 5]: expected call-signature: 'openConnectGitRepoDialog' to have a typedef
[89, 48]: == should be ===
[91, 41]: == should be ===
[93, 41]: == should be ===
[93, 87]: == should be ===
[121, 11]: comment must start with a space
[125, 11]: comment must start with a space
[196, 7]: Calls to 'console.log' are not allowed.
[200, 7]: Calls to 'console.log' are not allowed.
[202, 9]: Calls to 'console.log' are not allowed.


WARNING in ./src/app/layout/notification-stream/notification-stream.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[55, 3]: expected call-signature: 'ackAll' to have a typedef
[48, 5]: Missing blank line before return
[107, 7]: Missing blank line before return


WARNING in ./src/app/+run-tale/run-tale/modals/create-rename-version-dialog/create-rename-version-dialog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[6, 1]: Import sources within a group must be alphabetized.


WARNING in ./src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[6, 1]: Import sources within a group must be alphabetized.
[14, 1]: Import sources within a group must be alphabetized.
[18, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.
[102, 3]: expected call-signature: 'scrollToTop' to have a typedef
[166, 3]: expected call-signature: 'transformIdentifier' to have a typedef
[176, 42]: Use a template literal instead of concatenating with a string literal.
[51, 5]: Missing blank line before return
[67, 7]: Missing blank line before return
[98, 5]: Missing blank line before return
[170, 5]: Missing blank line before return
[177, 7]: Missing blank line before return
[191, 5]: Missing blank line before return
[177, 32]: block is empty
[18, 82]: Missing whitespace in interpolation start; expecting {{ expr }}
[18, 101]: Missing whitespace in interpolation end; expecting {{ expr }}
[18, 104]: Missing whitespace in interpolation start; expecting {{ expr }}
[18, 122]: Missing whitespace in interpolation end; expecting {{ expr }}


WARNING in ./src/app/shared/common/pipes/truncate.pipe.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[6, 3]: Remove unnecessary empty constructor.
[6, 17]: block is empty


WARNING in ./src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[60, 17]: comment must start with a space
[70, 72]: comment must start with a space
[106, 68]: comment must start with a space


WARNING in ./src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[63, 7]: Missing blank line before return


WARNING in ./src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[68, 122]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return', and wrapping the object literal in parentheses.
[68, 9]: Identifier 'preAddedDatasets' is never reassigned; use 'const' instead of 'let'.


WARNING in ./src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[683, 41]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return', and wrapping the object literal in parentheses.
[23, 1]: Import sources of the same type (package, same folder, different folder) must be grouped together.
[186, 3]: expected call-signature: 'delay' to have a typedef
[191, 9]: expected call-signature: 'uploadChunks' to have a typedef
[191, 65]: Type number trivially inferred from a number literal, remove type annotation
[331, 25]: Use a template literal instead of concatenating with a string literal.
[514, 7]: Missing blank line before return
[172, 5]: multiline comments are not allowed
[246, 9]: multiline comments are not allowed
[204, 9]: comment must start with a space
[205, 9]: comment must start with a space
[226, 11]: comment must start with a space
[331, 13]: Calls to 'console.log' are not allowed.


WARNING in ./src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[69, 7]: Reassigning parameter 'interval' is forbidden.
[42, 3]: expected call-signature: 'mergeLogs' to have a typedef
[65, 3]: expected call-signature: 'stopPolling' to have a typedef
[94, 3]: expected call-signature: 'ngOnDestroy' to have a typedef
[58, 15]: Use a template literal instead of concatenating with a string literal.
[53, 7]: Missing blank line before return


WARNING in ./src/app/framework/core/window.service.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[7, 3]: expected call-signature: 'open' to have a typedef


WARNING in ./src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[8, 1]: Import sources within a group must be alphabetized.
[154, 3]: expected call-signature: 'deleteVersion' to have a typedef
[103, 31]: Type string trivially inferred from a string literal, remove type annotation
[58, 61]: Missing whitespace in interpolation end; expecting {{ expr }}


WARNING in ./src/app/+tale-catalog/tale-catalog/pipes/shared-tales.pipe.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[8, 3]: Remove unnecessary empty constructor.
[15, 33]: This arrow function body can be simplified by omitting the curly braces and the keyword 'return'.
[3, 1]: Import sources within a group must be alphabetized.
[16, 32]: == should be ===
[16, 73]: == should be ===
[8, 17]: block is empty


WARNING in ./src/app/+tale-catalog/tale-catalog/pipes/my-tales.pipe.ts
Module Warning (from ./node_modules/tslint-loader/index.js):
[8, 3]: Remove unnecessary empty constructor.
[3, 1]: Import sources within a group must be alphabetized.
[15, 51]: == should be ===
[8, 17]: block is empty

ℹ ｢wdm｣: Compiled with warnings.
```