### PR TITLE
fix: redirect from run-tale to catalog on error

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -145,7 +145,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
                       .subscribe((tale: Tale) => {
         if (!tale) {
           this.logger.error("Tale is null, something went horribly wrong");
-
+          this.router.navigate(['public']);
           return;
         }
 
@@ -170,6 +170,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         });
       }, err => {
         this.logger.error("Failed to fetch tale:", err);
+        this.router.navigate(['public']);
       });
     }
 

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -146,6 +146,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         if (!tale) {
           this.logger.error("Tale is null, something went horribly wrong");
           this.router.navigate(['public']);
+
           return;
         }
 


### PR DESCRIPTION
## Problem
The EmberJS dashboard used to redirect the user to the browse view when an invalid Tale ID was encountered. AngularJS dashboard needs this behavior as well.

Fixes #108 

## Approach
Redirect to "public" catalog if an error is encountered fetching the Tale in the Run Tale view.

## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate directly to `/run/thisisnotarealid` in your browser
    * You should be redirected to the Public Tales catalog
