### PR TITLE
fix: fix tale-sharing tab

### DIFF
--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
@@ -118,7 +118,7 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
 
   initializeSearch(filteredUsers: Array<User>): void {
     // Initialize the user search
-    $('#userSearch').search.call(this, {
+    $('#userSearch').search({
       source: filteredUsers,
       type: 'standard',
       fullTextSearch: 'true',


### PR DESCRIPTION
## Problem
I accidentally broke the Sharing tab while fixing build warnings.

Fixes #120 

## Approach
Revert this change, since it was apparently not necessary anyways.

## How to Test
Prerequisites: at least one Tale created that you own

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
4. Navigate to Run Tale > Share for a Tale that you own
    * You should no longer see an error pop up about `addEventListener` failing