### PR TITLE
fix: ensure that tale-interact handles iframe=False

### DIFF
--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
@@ -14,7 +14,13 @@
 
         <div *ngIf="!instance.iframe" class="ui message">
             <p>This Tale must be run in a separate window.</p>
-            <p><a class="ui button primary" [href]="instance.url" target="_blank">Click here to comply</a></p>
+            <p><a class="ui button primary"
+                  [href]="instance.url"
+                  [matTooltipShowDelay]="2000"
+                  matTooltip="Take a deep breath. Calm your mind. You know what is best. What is best is you comply. Compliance will be rewarded."
+                  target="_blank">
+              Click here to comply</a>
+            </p>
         </div>
       </div>
 

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
@@ -13,14 +13,15 @@
         <iframe *ngIf="instance.iframe" height="100%" width="100%" [src]="instance.url | safe:'url'"></iframe>
 
         <div *ngIf="!instance.iframe" class="ui message">
-            This Tale must be run in a separate window.
-            <a class="ui button primary" [href]="instance.url" target="_blank">Click here to comply</a>
+            <p>This Tale must be run in a separate window.</p>
+            <p><a class="ui button primary" [href]="instance.url" target="_blank">Click here to comply</a></p>
         </div>
       </div>
 
       <!-- Error state -->
       <div *ngIf="instance.status === 2" class="status-banner">
-        <i class="fas fa-warning"></i>
+        <i class="fas fa-exclamation-triangle"></i> Something went wrong.
+        Please wait a few moments and try again.
       </div>
 
       <!-- Deleting state -->
@@ -30,8 +31,10 @@
       </div>
     </div>
 
-    <div class="sixteen wide column" *ngIf="!instance" class="status-banner">
-      You must Run this Tale before you can Interact.
+    <div class="sixteen wide column" *ngIf="!instance">
+      <div class="status-banner">
+        <h3>You must Run this Tale before you can Interact.</h3>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.scss
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.scss
@@ -17,3 +17,10 @@
 .status-banner .fas {
   margin-top: 10vh;
 }
+
+.ui.message {
+  width: 100%;
+  height: 60vh;
+  text-align: center;
+  padding-top: 15vh;
+}


### PR DESCRIPTION
## Problem
`tale-interact` tab may not properly handle cases when `iframe=False`

Fixes #116 

## Approach
Re-test this case and make sure styling is correct

<img width="1430" alt="Screen Shot 2021-01-25 at 3 47 46 PM" src="https://user-images.githubusercontent.com/1413653/105770388-c1cf9400-5f24-11eb-897a-b3313cdb28a1.png">


## How to Test
Prerequisites: at least on image with `iframe=False`:
  * You can use `GET/PUT /image/:id` on Swagger UI to toggle this easily

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a new Tale from the image with `iframe=False`
4. Click Run Tale to navigate to Tale Interact
    * You should see a message indicating that this Tale cannot run in a n iframe and that it needs to run in a new window
    * You should be offered a button to open the Tale in a new window