### PR TITLE
feat: add an autoscroll function to views-logs-modal

### DIFF
--- a/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.html
+++ b/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.html
@@ -11,5 +11,9 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
+  <div class="ui checkbox">
+    <input type="checkbox" name="stayAtBottom" [(ngModel)]="stayAtBottom" />
+    <label>Scroll to Bottom</label>
+  </div>
   <button class="ui black deny button" mat-dialog-close>Close</button>
 </mat-dialog-actions>

--- a/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.scss
+++ b/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.scss
@@ -1,3 +1,7 @@
+.mat-dialog-content {
+  overflow: hidden;
+}
+
 pre {
   max-height: 60vh;
 }
@@ -10,4 +14,9 @@ pre {
 #log-viewer-content {
   width: 70vw;
   height: 50vh;
+  overflow: auto;
+}
+
+.ui.checkbox {
+  margin-right: 20px;
 }

--- a/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
+++ b/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
@@ -55,11 +55,6 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
     return this.stayAtBottom;
   }
 
-  scrollToBottomChanged(element: any, event: any) {
-    this.logger.info('Toggled: ', element.checked);
-    this.stayAtBottom = element.checked;
-  }
-
   scrollToBottom(): void {
     setTimeout(() => {
       const id = 'log-viewer-content';

--- a/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
+++ b/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
@@ -98,12 +98,9 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
 
   autoFetch(jobId: string, intervalMs: number = this.refreshInterval): void {
     const interval: any = setInterval(() => {
-      this.logger.info('fetching...');
       this.jobService.jobGetJob(jobId).subscribe((job: Job) => {
-        this.logger.info('fetched!');
         // If job is done, stop polling
         if (job.status === 3) {
-          this.logger.info('stopping!');
           this.stopPolling(interval);
         }
 

--- a/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
+++ b/src/app/layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component.ts
@@ -16,6 +16,7 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
   refreshInterval = 2000;
   jobs: Array<Job> = [];
   intervals: Array<any> = [];
+  stayAtBottom = true;
 
   constructor(
     private readonly ref: ChangeDetectorRef,
@@ -35,8 +36,36 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
       });
     });
     const count = this.data.jobIds.length;
-    const latestJob = this.data.jobIds[count - 1];
+    const latestJob = this.data.jobIds.sort(
+      (a: string, b: string): number => {
+        if (a > b) {
+          return 1;
+        }
+        if (a < b) {
+          return -1;
+        }
+
+        return 0;
+      }
+    )[count - 1];
     this.autoFetch(latestJob);
+  }
+
+  shouldStayAtBottom(): boolean {
+    return this.stayAtBottom;
+  }
+
+  scrollToBottomChanged(element: any, event: any) {
+    this.logger.info('Toggled: ', element.checked);
+    this.stayAtBottom = element.checked;
+  }
+
+  scrollToBottom(): void {
+    setTimeout(() => {
+      const id = 'log-viewer-content';
+      const logViewer = document.getElementById(id);
+      logViewer.scrollTop = logViewer.scrollHeight;
+    }, 200);
   }
 
   mergeLogs(): void {
@@ -74,9 +103,12 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
 
   autoFetch(jobId: string, intervalMs: number = this.refreshInterval): void {
     const interval: any = setInterval(() => {
+      this.logger.info('fetching...');
       this.jobService.jobGetJob(jobId).subscribe((job: Job) => {
+        this.logger.info('fetched!');
         // If job is done, stop polling
         if (job.status === 3) {
+          this.logger.info('stopping!');
           this.stopPolling(interval);
         }
 
@@ -87,6 +119,11 @@ export class ViewLogsDialogComponent implements OnInit, OnDestroy {
 
         // Concatenate all logs together for display
         this.mergeLogs();
+
+        // If requested, keep scrolling at the bottom
+        if (this.shouldStayAtBottom()) {
+          this.scrollToBottom();
+        }
       });
     }, intervalMs);
 


### PR DESCRIPTION
## Problem
View Logs modal auto refreshes, but doesn't offer a way to follow the tail of the logs.

## Approach
Add a "Scroll to Bottom" checkbox to the View Logs modal, that is checked by default

## How to Test
Prerequisites: at least one Tale created, not running

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale
    * You should see the `notification-stream` appear at the top-right, offering the "View Logs" button
4. Click on "View Logs"
    * You should see the `view-logs-modal` appear
    * You should see a checkbox that reads "Scroll to Bottom" at the bottom-left
    * You should see that "Scroll to Bottom" is checked by default
5. Scroll up as the build output continues
    * You should be brought back to the bottom of the modal every 1-2 seconds
6. Uncheck "Scroll to Bottom" and scroll up once more
    * You should no longer be dragged to the bottom of the modal automatically