### PR TITLE
fix: make mine tab the default view

### DIFF
--- a/src/app/+tale-catalog/tale-catalog.routes.ts
+++ b/src/app/+tale-catalog/tale-catalog.routes.ts
@@ -11,7 +11,7 @@ export const routes = [
       {
           path: '',
           pathMatch: 'full',
-          redirectTo: 'public'
+          redirectTo: 'mine'
       },
       {
         path: 'public',

--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -20,7 +20,8 @@
 
       <!-- Placeholder Message -->
       <div class="ui message" *ngIf="!allStoppedTales.length">
-          You do not have any stopped Tales.
+          Looks like you don't own any Tales. Explore other users' Tales
+          <a [routerLink]="'/public'">here</a> or create a new one using the "Create New Tale" button above.
       </div>
 
       <div class="ui message" *ngIf="allStoppedTales.length && !filteredStoppedTales.length">

--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -20,8 +20,8 @@
 
       <!-- Placeholder Message -->
       <div class="ui message" *ngIf="!allStoppedTales.length">
-          Looks like you don't own any Tales. Explore other users' Tales
-          <a [routerLink]="'/public'">here</a> or create a new one using the "Create New Tale" button above.
+          You haven't created any Tales yet. Select the "Create New Tale" button above 
+          or <a [routerLink]="'/public'">explore Tales created by other users</a>.
       </div>
 
       <div class="ui message" *ngIf="allStoppedTales.length && !filteredStoppedTales.length">

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
@@ -5,11 +5,11 @@
 		<div class="row">
 			<div class="sixteen wide column">
 				<div class="ui secondary pointing menu">
-					<a routerLink="/public" routerLinkActive="active" class="item">
-						Public Tales
-					</a>
 					<a routerLink="/mine" routerLinkActive="active" class="item">
 						My Tales
+					</a>
+					<a routerLink="/public" routerLinkActive="active" class="item">
+						Public Tales
 					</a>
 					<a routerLink="/shared" routerLinkActive="active" class="item">
 						Shared with Me

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
@@ -8,11 +8,11 @@
 					<a routerLink="/mine" routerLinkActive="active" class="item">
 						My Tales
 					</a>
-					<a routerLink="/public" routerLinkActive="active" class="item">
-						Public Tales
-					</a>
 					<a routerLink="/shared" routerLinkActive="active" class="item">
 						Shared with Me
+					</a>
+					<a routerLink="/public" routerLinkActive="active" class="item">
+						Public Tales
 					</a>
 					<div class="right menu">
 						<div class="item no-phone">

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -1,7 +1,7 @@
 
 <div class="ui inverted menu wt-top">
-    <a class="header item wt-brand" routerLink="/public" routerLinkActive="active"><img src="assets/img/wholetale_logo_sm.png">Whole<span>Tale</span></a>
-    <a class="item" [ngClass]="{ 'active':currentRoute==='/public' || currentRoute==='/mine' }" routerLink="/public" routerLinkActive="active">Tale Dashboard</a>
+    <a class="header item wt-brand" routerLink="/mine" routerLinkActive="active"><img src="assets/img/wholetale_logo_sm.png">Whole<span>Tale</span></a>
+    <a class="item" [ngClass]="{ 'active':currentRoute==='/mine' || currentRoute==='/public' }" routerLink="/mine" routerLinkActive="active">Tale Dashboard</a>
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">


### PR DESCRIPTION
## Problem

"My Tales" should be the go-to place for users. (@craig-willis I'm well aware I said something totally opposite the other day. What can I say? I changed my mind :P)

## Approach

Make `/mine` a default path. Add more descriptive message in case user doesn't have any tales.

## How to Test

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. You should land on `/mine` tab. `Tale Dashboard` in the header should be highlighted.
4. If you don't have any Tales you should be greeted with a new longer message containing the link to `/public` (check that it works)
5. Everything in the header (i.e. wholetale logo and 'Tale dashboard') should direct you to /mine tab. 
