### PR TITLE
feat: support allowRename, fix race condition

### DIFF
--- a/src/app/+run-tale/run-tale/modals/create-rename-version-dialog/create-rename-version-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/create-rename-version-dialog/create-rename-version-dialog.component.html
@@ -17,7 +17,7 @@
                     <div class="sixteen wide column">
                         <div class="field" [ngClass]="{ 'error': nameAlreadyExists }">
                             <!-- Require new name in "Rename" mode -->
-                            <input *ngIf="data.mode==='create'" type="text" name="name" id="name" [(ngModel)]="name" (ngModelChange)="doesNameExist($event)" />
+                            <input *ngIf="data.mode==='create'" type="text" name="name" id="name" [(ngModel)]="name" />
                             <input *ngIf="data.mode!=='create'" type="text" name="name" id="name" [(ngModel)]="name" required (ngModelChange)="doesNameExist($event)" />
                         </div>
                     </div>
@@ -46,7 +46,7 @@
 
 <mat-dialog-actions>
   <button class="ui black deny button" mat-dialog-close>Cancel</button>
-  <button class="ui primary right labeled icon button" [mat-dialog-close]="getResult()" [disabled]="(data.mode !== 'create' && !name) || nameAlreadyExists">
+  <button class="ui primary right labeled icon button" [ngClass]="{ 'loading': submitLoading, 'disabled': submitLoading || nameAlreadyExists }" [mat-dialog-close]="getResult()" [disabled]="(data.mode !== 'create' && !name) || submitLoading || nameAlreadyExists">
     Save
     <i class="checkmark icon"></i>
   </button>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -86,7 +86,8 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges {
       const params: VersionService.VersionCreateVersionParams = {
         taleId: this.tale._id,
         name: result.name,
-        force: result.force
+        force: result.force,
+        allowRename: true
       };
 
       // Backend sets the name, if not provided

--- a/src/app/api/services/version.service.ts
+++ b/src/app/api/services/version.service.ts
@@ -33,7 +33,11 @@ class VersionService extends __BaseService {
     let __body: any = null;
     if (params.taleId != null) __params = __params.set('taleId', params.taleId.toString());
     if (params.name != null) __params = __params.set('name', params.name.toString());
-    if (params.force != null) __params = __params.set('force', params.force.toString());
+
+    // Set defaults for optional parameters
+    __params = __params.set('force', params.force != null ? params.force.toString() : 'false');
+    __params = __params.set('allowRename', params.allowRename != null ? params.allowRename.toString() : 'false');
+
     let req = new HttpRequest<any>('POST', this.rootUrl + VersionService.versionCreateVersionPath, __body, {
       headers: __headers,
       params: __params,
@@ -171,6 +175,7 @@ module VersionService {
     taleId: string;
     name?: string;
     force?: boolean;
+    allowRename?: boolean;
   }
 
   export interface VersionListVersionsParams {


### PR DESCRIPTION
## Problem
Race condition when validating name allows user to submit invalid data. They get an error popup, but we should prevent this behavior.

Fixes #117 

Based on https://github.com/whole-tale/wt_versioning/pull/18

## Approach
* For "Create" case: support `allowRename` during CreateVersion - this will guarantee unique version names by appending `(1)` or similar to resolve conflicts
* For "Rename" case: block submission of the form until name has been fully validated

## How to Test
Prerequisites: running https://github.com/whole-tale/wt_versioning/pull/18, at least one Tale created

### Test Setup
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Choose a Tale that you own and click "View"
4. Expand the Tale Versions Panel on the right side

### Test "Create" Case
1. Click on "Save New Version"
    * You should see the create-rename-version-modal appear
2. Enter `name` and submit (make sure `Force` is checked)
    * You should see that a new version called `name` appear in the list
3. Repeat steps 2 and 3
    * You should see that a new version called `name (1)` appear in the list

### Test "Rename" Case
1. Refresh the page
2. Expand the Tale Versions Panel on the right side
3. Expand the dropdown beside the Version called `name (1)` and choose "Rename"
    * You should see the create-rename-version-modal appear
4. Open the developer console to the Networks tab, expand the dropdown that says `Online`, and throttle your connection to a slower speed
5. Enter `name` in the modal
    * You should see the "Save" button is disabled while we validate the name you've entered
6. Wait for validation to complete
    * You should see the "Save" button is still disabled
    * You should see a red banner appear notifying you that the name is invalid