### PR TITLE
First-pass at a pattern for handling state updates from SSE

### DIFF
--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -8,7 +8,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Title</label>
           <div class="field thirteen wide column">
-            <input placeholder="Title is required." type="text" name="title" [(ngModel)]="tale.title" required>
+            <input placeholder="Title is required." type="text" name="title" [(ngModel)]="_editState.title" required>
           </div>
         </div>
 
@@ -17,7 +17,7 @@
           <div class="thirteen wide column" style="padding-left:0;">
             <h4 style="text-align: center">Created by <span style="color:#67c096">{{ creator.firstName }} {{ creator.lastName }}</span></h4>
 
-            <form id="taleAuthorsSubForm" #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="tale.authors.length">
+            <form id="taleAuthorsSubForm" #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="_editState.authors.length">
               <table class="ui table striped condensed">
                 <tr>
                   <th>First Name</th>
@@ -25,7 +25,7 @@
                   <th>ORCID</th>
                   <th></th>
                 </tr>
-                <tr *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorHash">
+                <tr *ngFor="let author of _editState.authors; index as i; trackBy: trackByAuthorHash">
                   <td><input type="text" name="firstName_{{i}}" placeholder="First name is required." [(ngModel)]="author.firstName" required></td>
                   <td><input type="text" name="lastName_{{i}}" placeholder="Last name is required." [(ngModel)]="author.lastName" required></td>
                   <td><input type="text" name="orcid_{{i}}" placeholder="ORCID is required." [(ngModel)]="author.orcid" required></td>
@@ -40,14 +40,14 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Category</label>
           <div class="field thirteen wide column">
-            <input placeholder="Category is required." type="text" name="category" [(ngModel)]="tale.category" required>
+            <input placeholder="Category is required." type="text" name="category" [(ngModel)]="_editState.category" required>
           </div>
         </div>
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Environment</label>
           <div class="field thirteen wide column">
-              <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="tale.imageId">
+              <select id="environmentDropdown" class="ui labeled icon fluid dropdown" name="imageId" [(ngModel)]="_editState.imageId">
                   <option class="item" [ngValue]="env._id" *ngFor="let env of (environments | async); index as i; trackBy: trackById">
                   <img class="ui avatar image" [src]="env.icon | safe:'url'" />
                   {{ env.name }}
@@ -60,8 +60,8 @@
           <label class="two wide column right aligned">Datasets used</label>
           <span *ngIf="!tale.dataSetCitation">No citable data</span>
           <ul *ngIf="tale.dataSetCitation" style="max-width:60vw">
-              <li *ngFor="let citation of tale.dataSetCitation">
-                  <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
+              <li *ngFor="let citation of _editState.dataSetCitation">
+                  <a routerLink="/run/{{ _editState._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
                       {{ citation }}
                   </a>
               </li>
@@ -71,7 +71,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">License</label>
           <div class="field thirteen wide column">
-              <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="tale.licenseSPDX">
+              <select id="licenseDropdown" class="ui labeled icon fluid dropdown" name="licenseSPDX" [(ngModel)]="_editState.licenseSPDX">
                   <option class="item" [ngValue]="license.spdx" *ngFor="let license of (licenses | async); index as i; trackBy: trackBySpdx">
                   {{ license.name }}
                   </option>
@@ -82,14 +82,14 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Date created</label>
           <div class="field thirteen wide column">
-            <span>{{ tale.created | date:'full' }}</span>
+            <span>{{ _editState.created | date:'full' }}</span>
           </div>
         </div>
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Last updated</label>
           <div class="field thirteen wide column">
-            <span>{{ tale.updated | date:'full' }}</span>
+            <span>{{ _editState.updated | date:'full' }}</span>
           </div>
         </div>
 
@@ -107,10 +107,10 @@
               </a>
             </div>
             <div class="ui bottom attached tab segment" [ngClass]="{ 'active': !previewMarkdown }">
-              <textarea rows="5" type="text" name="description" placeholder="Description is required." [(ngModel)]="tale.description" required></textarea>
+              <textarea rows="5" type="text" name="description" placeholder="Description is required." [(ngModel)]="_editState.description" required></textarea>
             </div>
             <div class="ui bottom attached tab segment" [ngClass]="{ 'active': previewMarkdown }">
-              <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+              <markdown ngPreserveWhitespaces [data]="_editState.description"></markdown>
             </div>
           </div>
         </div>
@@ -119,7 +119,7 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Illustration</label>
           <div class="ui action field thirteen wide column">
-            <input placeholder="http://" type="text" name="icon" [(ngModel)]="tale.illustration">
+            <input placeholder="http://" type="text" name="icon" [(ngModel)]="_editState.illustration">
             <div class="or"></div>
             <button class="ui blue button" (click)="generateIcon()">Generate Illustration</button>
           </div>
@@ -145,8 +145,8 @@
 
           <div class="field toggle ui checkbox four wide column">
             <input type="checkbox" name="public"
-                [checked]="tale.public"
-                (change)="tale.public=!tale.public">
+                [checked]="_editState.public"
+                (change)="_editState.public=!_editState.public">
             <label>Public?</label>
           </div>
         </div>

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -103,10 +103,10 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
       this.refresh();
     });
 
-    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe((taleId: string) => {
+    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe((resource: { taleId: string, instanceId: string }) => {
       this.refresh();
     });
-    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe((taleId: string) => {
+    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe((resource: { taleId: string, instanceId: string }) => {
       this.refresh();
     });
   }

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, NgZone, OnChanges, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, NgZone, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AccessLevel } from '@api/models/access-level';
 import { Instance } from '@api/models/instance';
@@ -10,6 +10,7 @@ import { UserService } from '@api/services/user.service';
 import { TokenService } from '@api/token.service';
 import { LogService } from '@framework/core/log.service';
 import { TaleAuthor } from '@tales/models/tale-author';
+import { SyncService } from '@tales/sync.service';
 import { Observable, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -23,10 +24,24 @@ declare var $: any;
   styleUrls: ['./public-tales.component.scss'],
   selector: 'app-public-tales'
 })
-export class PublicTalesComponent implements OnChanges, OnInit {
+export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
   tales$: Observable<Array<Tale>> = new Observable<Array<Tale>>();
   tales: Array<Tale> = [];
   publicTales: Array<Tale> = [];
+
+  taleCreatedSubscription: Subscription;
+  taleUpdatedSubscription: Subscription;
+  taleRemovedSubscription: Subscription;
+
+  taleImportStartedSubscription: Subscription;
+  taleImportCompletedSubscription: Subscription;
+  taleImportFailedSubscription: Subscription;
+
+  taleSharedSubscription: Subscription;
+  taleUnsharedSubscription: Subscription;
+
+  instanceLaunchingSubscription: Subscription;
+  instanceRunningSubscription: Subscription;
 
   AccessLevel: any = AccessLevel;
 
@@ -50,7 +65,8 @@ export class PublicTalesComponent implements OnChanges, OnInit {
     private logger: LogService,
     private taleService: TaleService,
     private instanceService: InstanceService,
-    private userService: UserService
+    private userService: UserService,
+    private syncService: SyncService
   ) { }
 
   ngOnInit(): void {
@@ -60,10 +76,59 @@ export class PublicTalesComponent implements OnChanges, OnInit {
       this.user = user;
     });
     this.refresh();
+    this.taleCreatedSubscription = this.syncService.taleCreatedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+    this.taleRemovedSubscription = this.syncService.taleRemovedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+    this.taleUpdatedSubscription = this.syncService.taleUpdatedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+
+    this.taleSharedSubscription = this.syncService.taleSharedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+    this.taleUnsharedSubscription = this.syncService.taleUnsharedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+
+    this.taleImportStartedSubscription = this.syncService.taleImportFailedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+    this.taleImportCompletedSubscription = this.syncService.taleImportCompletedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+    this.taleImportFailedSubscription = this.syncService.taleImportFailedSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+
+    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
+    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe((taleId: string) => {
+      this.refresh();
+    });
   }
 
   ngOnChanges(): void {
     this.refresh();
+  }
+
+  ngOnDestroy(): void {
+    this.taleCreatedSubscription.unsubscribe();
+    this.taleUpdatedSubscription.unsubscribe();
+    this.taleRemovedSubscription.unsubscribe();
+
+    this.taleSharedSubscription.unsubscribe();
+    this.taleUnsharedSubscription.unsubscribe();
+
+    this.taleImportCompletedSubscription.unsubscribe();
+    this.taleImportStartedSubscription.unsubscribe();
+    this.taleImportFailedSubscription.unsubscribe();
+
+    this.instanceLaunchingSubscription.unsubscribe();
+    this.instanceRunningSubscription.unsubscribe();
   }
 
   taleInstanceStateChanged(updated: {tale: Tale, instance: Instance}): void {
@@ -92,6 +157,8 @@ export class PublicTalesComponent implements OnChanges, OnInit {
 
   // Refresh tale/instance data from the server
   refresh(): void {
+    this.ref.detectChanges();
+
     // Fetch a map of taleId => instance
     const listInstancesParams = {};
     this.instanceService.instanceListInstances(listInstancesParams).subscribe((instances: Array<Instance>) => {
@@ -109,6 +176,7 @@ export class PublicTalesComponent implements OnChanges, OnInit {
     this.taleService.taleListTales(listTalesParams).subscribe((tales: Array<Tale>) => {
       // Filter based on search query
       this.tales = tales;
+      this.tales$ = this.taleService.taleListTales(listTalesParams);
       this.ref.detectChanges();
 
       // For each tale, also fetch its creator

--- a/src/app/api/events/event-data.ts
+++ b/src/app/api/events/event-data.ts
@@ -42,16 +42,17 @@ export interface EventData {
     // Our custom resource, which includes associated IDs relevant to this message
     event: string;
     resourceName: string;
-    resource:
-      | any
-      | string
-      | {
-          /* type=wt_progress */
-          instance_id?: string; // ID of the Instance for which this message is relevant
-          jobs?: Array<string>; // Job IDs associated with this progress update
-          tale_id?: string; // ID of the Tale for which this message is relevant
-          tale_title?: string; // Title of the Tale
-          type?: string; // WT job name (e.g. "wt_create_instance")
-        };
+    affectedResourceIds: {
+      instanceId: string;
+      taleId: string;
+    };
+    resource: {
+      /* type=wt_progress */
+      instance_id?: string; // ID of the Instance for which this message is relevant
+      jobs?: Array<string>; // Job IDs associated with this progress update
+      tale_id?: string; // ID of the Tale for which this message is relevant
+      tale_title?: string; // Title of the Tale
+      type?: string; // WT job name (e.g. "wt_create_instance")
+    };
   };
 }

--- a/src/app/api/events/event-data.ts
+++ b/src/app/api/events/event-data.ts
@@ -24,6 +24,9 @@ export interface EventData {
 
   // Data payload for the message
   data: {
+    /* type=wt_tale_updated */
+    modelType?: string; // The type of model this update affects
+
     // Message payload
     state: string; // status of the overall operation
     title: string; // unused - effectively a friendly job name= (e.g. "Creating instance")
@@ -37,13 +40,18 @@ export interface EventData {
     estimateTime: boolean; // True if a time estimate is provided
 
     // Our custom resource, which includes associated IDs relevant to this message
+    event: string;
     resourceName: string;
-    resource: {
-      instance_id?: string; // ID of the Instance for which this message is relevant
-      jobs?: Array<string>; // Job IDs associated with this progress update
-      tale_id?: string; // ID of the Tale for which this message is relevant
-      tale_title?: string; // Title of the Tale
-      type?: string; // WT job name (e.g. "wt_create_instance")
-    };
+    resource:
+      | any
+      | string
+      | {
+          /* type=wt_progress */
+          instance_id?: string; // ID of the Instance for which this message is relevant
+          jobs?: Array<string>; // Job IDs associated with this progress update
+          tale_id?: string; // ID of the Tale for which this message is relevant
+          tale_title?: string; // Title of the Tale
+          type?: string; // WT job name (e.g. "wt_create_instance")
+        };
   };
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { ConfigLoader, ConfigService } from '@ngx-config/core';
 import { MetaLoader } from '@ngx-meta/core';
 import { TranslateLoader, TranslateService } from '@ngx-translate/core';
 import { ErrorHandlerModule } from '@shared/error-handler/error-handler.module';
+import { SyncService } from '@tales/sync.service';
 import { ANGULARTICS2_TOKEN } from 'angulartics2';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 import { CookieService } from 'ngx-cookie-service';
@@ -37,7 +38,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = { supp
 @NgModule({
   imports: [
     BrowserModule.withServerTransition({ appId: 'my-app-id' }),
-    TransferHttpCacheModule,
+    // TransferHttpCacheModule,
     RouterModule.forRoot(routes),
     PerfectScrollbarModule,
     ErrorHandlerModule,
@@ -83,7 +84,8 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = { supp
       provide: PERFECT_SCROLLBAR_CONFIG,
       useValue: DEFAULT_PERFECT_SCROLLBAR_CONFIG
     },
-    CookieService
+    CookieService,
+    SyncService
   ],
   exports: [AppComponent],
   entryComponents: [ChangeLanguageComponent],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,13 +11,14 @@ import { ConfigLoader, ConfigService } from '@ngx-config/core';
 import { MetaLoader } from '@ngx-meta/core';
 import { TranslateLoader, TranslateService } from '@ngx-translate/core';
 import { ErrorHandlerModule } from '@shared/error-handler/error-handler.module';
+import { SharedModule } from '@shared/shared.module';
 import { SyncService } from '@tales/sync.service';
 import { ANGULARTICS2_TOKEN } from 'angulartics2';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 import { CookieService } from 'ngx-cookie-service';
 import { PERFECT_SCROLLBAR_CONFIG, PerfectScrollbarConfigInterface, PerfectScrollbarModule } from 'ngx-perfect-scrollbar';
 import { AnalyticsModule } from '~/app/framework/analytics';
-import { configFactory, CoreModule, metaFactory, SharedModule } from '~/app/framework/core';
+import { configFactory, CoreModule, metaFactory, SharedModule as SharedCoreModule } from '~/app/framework/core';
 import { HttpInterceptorModule } from '~/app/framework/http';
 import { ChangeLanguageComponent, I18NModule, translateFactory } from '~/app/framework/i18n';
 import { MaterialModule } from '~/app/framework/material';
@@ -63,6 +64,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = { supp
         deps: [ConfigService, TranslateService]
       }
     ]),
+    SharedCoreModule,
     SharedModule,
     HttpInterceptorModule,
     I18NModule.forRoot([

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -72,8 +72,27 @@ export class NotificationStreamComponent {
     switch (event) {
       case 'wt_tale_updated':
         return this.sync.taleUpdated(resource);
-      // case "wt_tale_created":
-      //  return this.sync.taleCreated(resource);
+      case 'wt_tale_created':
+        return this.sync.taleCreated(resource);
+      case 'wt_tale_removed':
+        return this.sync.taleRemoved(resource);
+
+      case 'wt_tale_shared':
+        return this.sync.taleShared(resource);
+      case 'wt_tale_unshared':
+        return this.sync.taleUnshared(resource);
+
+      case 'wt_import_started':
+        return this.sync.taleImportStarted(resource);
+      case 'wt_import_completed':
+        return this.sync.taleImportCompleted(resource);
+      case 'wt_import_failed':
+        return this.sync.taleImportFailed(resource);
+
+      case 'wt_instance_launching':
+        return this.sync.instanceLaunching(resource);
+      case 'wt_instance_running':
+        return this.sync.instanceRunning(resource);
       default:
         this.logger.info('Unrecognized update event: ' + event);
         break;

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -65,34 +65,34 @@ export class NotificationStreamComponent {
   onMessage(girderEvent: GirderEvent): void {
     // Discard everything outside of "data"
     const eventData: EventData = JSON.parse(girderEvent.data);
-    const { modelType, resource, resourceName, event } = eventData.data;
+    const { affectedResourceIds, event } = eventData.data;
 
     // FIXME: this should use `eventData.type` instead, or adjust wt_progress + others
     // Handle resource-specific updates
     switch (event) {
       case 'wt_tale_updated':
-        return this.sync.taleUpdated(resource);
+        return this.sync.taleUpdated(affectedResourceIds.taleId);
       case 'wt_tale_created':
-        return this.sync.taleCreated(resource);
+        return this.sync.taleCreated(affectedResourceIds.taleId);
       case 'wt_tale_removed':
-        return this.sync.taleRemoved(resource);
+        return this.sync.taleRemoved(affectedResourceIds.taleId);
 
       case 'wt_tale_shared':
-        return this.sync.taleShared(resource);
+        return this.sync.taleShared(affectedResourceIds.taleId);
       case 'wt_tale_unshared':
-        return this.sync.taleUnshared(resource);
+        return this.sync.taleUnshared(affectedResourceIds.taleId);
 
       case 'wt_import_started':
-        return this.sync.taleImportStarted(resource);
+        return this.sync.taleImportStarted(affectedResourceIds.taleId);
       case 'wt_import_completed':
-        return this.sync.taleImportCompleted(resource);
+        return this.sync.taleImportCompleted(affectedResourceIds.taleId);
       case 'wt_import_failed':
-        return this.sync.taleImportFailed(resource);
+        return this.sync.taleImportFailed(affectedResourceIds.taleId);
 
       case 'wt_instance_launching':
-        return this.sync.instanceLaunching(resource);
+        return this.sync.instanceLaunching(affectedResourceIds.taleId, affectedResourceIds.instanceId);
       case 'wt_instance_running':
-        return this.sync.instanceRunning(resource);
+        return this.sync.instanceRunning(affectedResourceIds.taleId, affectedResourceIds.instanceId);
       default:
         this.logger.info('Unrecognized update event: ' + event);
         break;

--- a/src/app/layout/notification-stream/notification-stream.module.ts
+++ b/src/app/layout/notification-stream/notification-stream.module.ts
@@ -3,7 +3,6 @@ import { NgModule } from '@angular/core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { SharedModule } from '@framework/core';
 import { MaterialModule } from '@framework/material';
-import { TalesService } from '@tales/tales.service';
 
 import { ViewLogsDialogComponent } from './modals/view-logs-dialog/view-logs-dialog.component';
 import { NotificationStreamComponent } from './notification-stream.component';
@@ -12,7 +11,7 @@ import { NotificationStreamService } from './notification-stream.service';
 @NgModule({
   declarations: [NotificationStreamComponent, ViewLogsDialogComponent],
   exports: [NotificationStreamComponent],
-  providers: [NotificationStreamService],
+  providers: [],
   imports: [CommonModule, SharedModule, MaterialModule, MatDialogModule],
   entryComponents: [ViewLogsDialogComponent]
 })

--- a/src/app/layout/notification-stream/notification-stream.service.ts
+++ b/src/app/layout/notification-stream/notification-stream.service.ts
@@ -12,8 +12,8 @@ import { bypassSanitizationTrustResourceUrl } from '@angular/core/src/sanitizati
 })
 class NotificationStreamService implements OnDestroy {
   static readonly Path = '/notification/stream';
-  static readonly TimeoutMs = 30;
-  static readonly IntervalDelayMs = 30000;
+  static readonly TimeoutMs = 85;
+  static readonly IntervalDelayMs = 85000;
   private _since: number = 0;
 
   interval: any;
@@ -96,7 +96,7 @@ class NotificationStreamService implements OnDestroy {
     this.disconnect();
 
     // Connect to SSE using the given parameters
-    this.source = new EventSource(this.url, { headers: { 'Girder-Token': this.token } });
+    this.source = new EventSource(this.url, { headers: { 'Girder-Token': this.token }, heartbeatTimeout: 90000 });
 
     this.source.onerror = this.onError.bind(this);
     this.source.onopen = this.onOpen.bind(this);

--- a/src/app/shared/common/common.module.ts
+++ b/src/app/shared/common/common.module.ts
@@ -1,18 +1,22 @@
 import { CommonModule as CommonAngularModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MaterialModule } from '@framework/material';
 
+import { AlertModalComponent } from './components/alert-modal/alert-modal.component';
+import { ConfirmationModalComponent } from './components/confirmation-modal/confirmation-modal.component';
 import { LoadingOverlayComponent } from './components/loading-overlay/loading-overlay.component';
 import { MenuGroupComponent } from './components/menu/menu-group.component';
 import { MenuItemComponent } from './components/menu/menu-item.component';
 import { TruncatePipe } from './pipes/truncate.pipe';
 
-const COMPONENTS = [LoadingOverlayComponent, MenuGroupComponent, MenuItemComponent];
+const COMPONENTS = [LoadingOverlayComponent, MenuGroupComponent, MenuItemComponent, ConfirmationModalComponent, AlertModalComponent];
 
 @NgModule({
-  imports: [CommonAngularModule, FormsModule, MaterialModule],
+  imports: [CommonAngularModule, FormsModule, MaterialModule, MatDialogModule],
   declarations: [COMPONENTS, TruncatePipe],
-  exports: [CommonAngularModule, COMPONENTS, TruncatePipe]
+  exports: [CommonAngularModule, COMPONENTS, TruncatePipe],
+  entryComponents: [ConfirmationModalComponent, AlertModalComponent]
 })
 export class CommonModule {}

--- a/src/app/shared/common/components/alert-modal/alert-modal.component.html
+++ b/src/app/shared/common/components/alert-modal/alert-modal.component.html
@@ -1,0 +1,12 @@
+<h1 mat-dialog-title>{{ data.title || 'Alert' }}</h1>
+
+<mat-dialog-content>
+  <p *ngFor="let message of data.content">{{ message }}</p>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button class="ui positive right labeled icon button" [mat-dialog-close]="true">
+    OK
+    <i class="play icon"></i>
+  </button>
+</mat-dialog-actions>

--- a/src/app/shared/common/components/alert-modal/alert-modal.component.spec.ts
+++ b/src/app/shared/common/components/alert-modal/alert-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertModalComponent } from './alert-modal.component';
+
+describe('AlertModalComponent', () => {
+  let component: AlertModalComponent;
+  let fixture: ComponentFixture<AlertModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AlertModalComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlertModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/common/components/alert-modal/alert-modal.component.ts
+++ b/src/app/shared/common/components/alert-modal/alert-modal.component.ts
@@ -1,0 +1,13 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  templateUrl: './alert-modal.component.html',
+  styleUrls: ['./alert-modal.component.scss']
+})
+export class AlertModalComponent {
+  constructor(
+    private readonly dialogRef: MatDialogRef<AlertModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { content: Array<string>; title?: string }
+  ) {}
+}

--- a/src/app/shared/common/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/common/components/confirmation-modal/confirmation-modal.component.html
@@ -1,0 +1,13 @@
+<h1 mat-dialog-title>{{ data.title || 'Confirmation Required' }}</h1>
+
+<mat-dialog-content>
+  <p *ngFor="let message of data.content">{{ message }}</p>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button class="ui black deny button" mat-dialog-close>No</button>
+  <button class="ui positive right labeled icon button" [mat-dialog-close]="true">
+    Yes
+    <i class="play icon"></i>
+  </button>
+</mat-dialog-actions>

--- a/src/app/shared/common/components/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/app/shared/common/components/confirmation-modal/confirmation-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmationModalComponent } from './confirmation-modal.component';
+
+describe('ConfirmationModalComponent', () => {
+  let component: ConfirmationModalComponent;
+  let fixture: ComponentFixture<ConfirmationModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ConfirmationModalComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmationModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/common/components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/common/components/confirmation-modal/confirmation-modal.component.ts
@@ -1,0 +1,14 @@
+import { Component, Inject } from '@angular/core';
+
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  templateUrl: './confirmation-modal.component.html',
+  styleUrls: ['./confirmation-modal.component.scss']
+})
+export class ConfirmationModalComponent {
+  constructor(
+    private readonly dialogRef: MatDialogRef<ConfirmationModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { content: Array<string>; title?: string }
+  ) {}
+}

--- a/src/app/shared/error-handler/error-handler.module.ts
+++ b/src/app/shared/error-handler/error-handler.module.ts
@@ -16,7 +16,7 @@ import { ErrorService } from './services/error.service';
   providers: [
     ErrorService,
     LogService,
-    { provide: ErrorHandler, useClass: GlobalErrorHandler },
+    //{ provide: ErrorHandler, useClass: GlobalErrorHandler },
     { provide: HTTP_INTERCEPTORS, useClass: ServerErrorInterceptor, multi: true }
   ],
   entryComponents: [ErrorModalComponent]

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -43,17 +43,37 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe((instanceId: string) => {
-      // TODO: How do we know that this instance is for the Tale that this button represents?
-    });
-    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe((instanceId: string) => {
-      // TODO: How do we know that this instance is for the Tale that this button represents?
-    });
+    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe(
+      (resource: { taleId: string; instanceId: string }) => {
+        // Ignore updates that aren't for this Tale
+        if (resource.taleId != this.tale._id) {
+          return;
+        }
+
+        this.instanceService.instanceGetInstance(resource.instanceId).subscribe((instance: Instance) => {
+          this.instance = instance;
+          this.ref.detectChanges();
+        });
+      }
+    );
+    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe(
+      (resource: { taleId: string; instanceId: string }) => {
+        // Ignore updates that aren't for this Tale
+        if (resource.taleId != this.tale._id) {
+          return;
+        }
+
+        this.instanceService.instanceGetInstance(resource.instanceId).subscribe((instance: Instance) => {
+          this.instance = instance;
+          this.ref.detectChanges();
+        });
+      }
+    );
   }
 
   ngOnChanges(): void {
     if (this.instance && (this.instance.status === 0 || this.instance.status === 3)) {
-      this.autoRefresh();
+      // this.autoRefresh();
     }
   }
 
@@ -129,7 +149,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
 
         // Poll / wait for launch
         // TODO: Fix edge cases (refresh, etc)
-        this.autoRefresh();
+        // this.autoRefresh();
       },
       (err: any) => {
         this.logger.error('Failed to create instance:', err);

--- a/src/app/tales/sync.service.ts
+++ b/src/app/tales/sync.service.ts
@@ -7,16 +7,66 @@ import { Subject } from 'rxjs';
   providedIn: 'root'
 })
 export class SyncService {
-  readonly taleSubject = new Subject<string>();
+  readonly taleCreatedSubject = new Subject<string>();
+  readonly taleUpdatedSubject = new Subject<string>();
+  readonly taleSharedSubject = new Subject<string>();
+  readonly taleUnsharedSubject = new Subject<string>();
+  readonly taleRemovedSubject = new Subject<string>();
+
+  readonly taleImportStartedSubject = new Subject<string>();
+  readonly taleImportCompletedSubject = new Subject<string>();
+  readonly taleImportFailedSubject = new Subject<string>();
+
+  readonly instanceLaunchingSubject = new Subject<string>();
+  readonly instanceRunningSubject = new Subject<string>();
 
   constructor(private readonly logger: LogService) {}
-
+  taleCreated(taleId: string): void {
+    this.logger.info('Creating Tale via SyncService: ', taleId);
+    this.delay(() => this.taleCreatedSubject.next(taleId));
+  }
   taleUpdated(taleId: string): void {
     this.logger.info('Updating Tale via SyncService: ', taleId);
-    this.taleSubject.next(taleId);
+    this.delay(() => this.taleUpdatedSubject.next(taleId));
   }
-  instanceUpdated(instanceId: string): void {
+  taleRemoved(taleId: string): void {
+    this.logger.info('Removing Tale via SyncService: ', taleId);
+    this.delay(() => this.taleRemovedSubject.next(taleId));
+  }
+
+  taleShared(taleId: string): void {
+    this.logger.info('Sharing Tale via SyncService: ', taleId);
+    this.delay(() => this.taleSharedSubject.next(taleId));
+  }
+  taleUnshared(taleId: string): void {
+    this.logger.info('Unsharing Tale via SyncService: ', taleId);
+    this.delay(() => this.taleUnsharedSubject.next(taleId));
+  }
+
+  instanceLaunching(instanceId: string): void {
     this.logger.info('Updating Instance via SyncService: ', instanceId);
-    this.taleSubject.next(instanceId);
+    this.delay(() => this.instanceLaunchingSubject.next(instanceId));
+  }
+  instanceRunning(instanceId: string): void {
+    this.logger.info('Updating Instance via SyncService: ', instanceId);
+    this.delay(() => this.instanceRunningSubject.next(instanceId));
+  }
+
+  // TODO: Indicate Tale import state in UI
+  taleImportStarted(taleId: string): void {
+    this.logger.info('Importing Tale via SyncService: ', taleId);
+    this.delay(() => this.taleImportStartedSubject.next(taleId));
+  }
+  taleImportCompleted(taleId: string): void {
+    this.logger.info('Import completed via SyncService: ', taleId);
+    this.delay(() => this.taleImportCompletedSubject.next(taleId));
+  }
+  taleImportFailed(taleId: string): void {
+    this.logger.info('Import failed via SyncService: ', taleId);
+    this.delay(() => this.taleImportFailedSubject.next(taleId));
+  }
+
+  private delay(fn: Function, delayMs = 1000): void {
+    setTimeout(fn, delayMs);
   }
 }

--- a/src/app/tales/sync.service.ts
+++ b/src/app/tales/sync.service.ts
@@ -17,8 +17,8 @@ export class SyncService {
   readonly taleImportCompletedSubject = new Subject<string>();
   readonly taleImportFailedSubject = new Subject<string>();
 
-  readonly instanceLaunchingSubject = new Subject<string>();
-  readonly instanceRunningSubject = new Subject<string>();
+  readonly instanceLaunchingSubject = new Subject<{ taleId: string; instanceId: string }>();
+  readonly instanceRunningSubject = new Subject<{ taleId: string; instanceId: string }>();
 
   constructor(private readonly logger: LogService) {}
   taleCreated(taleId: string): void {
@@ -43,13 +43,13 @@ export class SyncService {
     this.delay(() => this.taleUnsharedSubject.next(taleId));
   }
 
-  instanceLaunching(instanceId: string): void {
+  instanceLaunching(taleId: string, instanceId: string): void {
     this.logger.info('Updating Instance via SyncService: ', instanceId);
-    this.delay(() => this.instanceLaunchingSubject.next(instanceId));
+    this.delay(() => this.instanceLaunchingSubject.next({ taleId, instanceId }));
   }
-  instanceRunning(instanceId: string): void {
+  instanceRunning(taleId: string, instanceId: string): void {
     this.logger.info('Updating Instance via SyncService: ', instanceId);
-    this.delay(() => this.instanceRunningSubject.next(instanceId));
+    this.delay(() => this.instanceRunningSubject.next({ taleId, instanceId }));
   }
 
   // TODO: Indicate Tale import state in UI

--- a/src/app/tales/sync.service.ts
+++ b/src/app/tales/sync.service.ts
@@ -1,0 +1,22 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { LogService } from '@framework/core/log.service';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SyncService {
+  readonly taleSubject = new Subject<string>();
+
+  constructor(private readonly logger: LogService) {}
+
+  taleUpdated(taleId: string): void {
+    this.logger.info('Updating Tale via SyncService: ', taleId);
+    this.taleSubject.next(taleId);
+  }
+  instanceUpdated(instanceId: string): void {
+    this.logger.info('Updating Instance via SyncService: ', instanceId);
+    this.taleSubject.next(instanceId);
+  }
+}


### PR DESCRIPTION
## Problem
When multiple browser tabs are open, any edits to the Tale in one browser cause the other tabs to go out of sync. 

## Approach
Integrate with https://github.com/whole-tale/girder_wholetale/pull/445 to provide updates to the UI state via Server-Side Eventing. As resources change in the backend, we will attempt to refresh the frontend data to keep the state in sync.

I am currently only handling `wt_tale_updated` event in the `run-tale` component and subviews to test out the pattern, and will start expanding to cover the other state update events that the backend is sending.

NOTE: There was a `TransferHttpCacheModule` that was caching GET requests. I have blindly disabled it for now, so we may see a (hopefully minor) performance hit. If the platform becomes unstable as a result, I can look into trying to disable it only for particular resources. Also noting that if/when any HTTP polling is cleaned up, this should ultimately result in an increase in performance.

## How to Test
Prerequisites: at least one Tale created by you

### Setup
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard

### Tale Created
1. Navigate to your Tale Catalog (e.g. "My Tales")
2. Right-click the browse tab and choose "Duplicate" to open another tab to the same view
3. In one tab, create a new Tale
4. Switch to the second tab
    * After a short delay, you should see that Tale you just created appears in the other tab

### Tale Removed
1. Navigate to your Tale Catalog (e.g. "My Tales")
2. Right-click the browse tab and choose "Duplicate" to open another tab to the same view
3. In one tab, delete an existing Tale
4. Switch to the second tab
    * After a short delay, you should see that Tale you just removed is deleted in the other tab as well

### Tale Updated
1. Navigate to Run > Metadata for your Tale
2. Right-click the browse tab and choose "Duplicate" to open another tab to the same view
3. In one tab, edit the name of the Tale and click "Save"
4. Switch to the second tab
    * After a short delay, you should see that the Tale name in the second tab is automatically updated to match the value that you entered in the first tab

### Tale Updated While Editing
1. Navigate to Run > Metadata for your Tale
2. Right-click the browse tab and choose "Duplicate" to open another tab to the same view
3. In **both tabs**, enter Edit mode for the same Tale
3. In one tab, edit the name of the Tale and click "Save"
4. Switch to the second tab
    * After a short delay, you should see the dashboard popup a modal asking if you would like to sync this Tale's changes

### Tale Shared / Unshared
TBD: Implemented, but needs testing

### Instance Launching / Running
TBD: Not implemented - `taleId` might be helpful to return here in addition to `instanceId`

### Tale Import Started / Completed / Failed
TBD: Not implemented - out of scope