### PR TITLE
Export Versions

### DIFF
--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -49,6 +49,7 @@
 
                 <div class="item" (click)="renameVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Rename</div>
                 <div class="item" (click)="deleteVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Delete</div>
+                <div class="item" (click)="exportVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Export</div>
               </div>
           </div>
         </div>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -1,11 +1,14 @@
 import { ChangeDetectorRef, Component, Input, NgZone, OnChanges, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { ApiConfiguration } from '@api/api-configuration';
 import { AccessLevel } from '@api/models/access-level';
 import { Tale } from '@api/models/tale';
 import { Version } from '@api/models/version';
 import { TaleService } from '@api/services/tale.service';
 import { VersionService } from '@api/services/version.service';
+import { TokenService } from '@api/token.service';
 import { LogService } from '@framework/core/log.service';
+import { WindowService } from '@framework/core/window.service';
 import { enterZone } from '@framework/ngrx/enter-zone.operator';
 import { NotificationService } from '@shared/error-handler/services/notification.service';
 import { TaleAuthor } from '@tales/models/tale-author';
@@ -29,14 +32,16 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges {
   timeline: Array<any> = [];
   AccessLevel = AccessLevel;
 
-  constructor(private ref: ChangeDetectorRef,
+  constructor(private config: ApiConfiguration,
+              private ref: ChangeDetectorRef,
               private zone: NgZone,
               private logger: LogService,
               private taleService: TaleService,
+              private tokenService: TokenService,
               private versionService: VersionService,
               private dialog: MatDialog,
-              private notificationService: NotificationService) {
-
+              private notificationService: NotificationService,
+              private windowService: WindowService) {
   }
 
   ngOnInit(): void {
@@ -151,6 +156,12 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges {
         this.notificationService.showError("Error: something went wrong.");
       });
     });
+  }
+
+  exportVersion(version: Version): void {
+    const token = this.tokenService.getToken();
+    const url = `${this.config.rootUrl}/tale/${this.tale._id}/export?token=${token}&taleFormat=bagit&versionId=${version._id}`;
+    this.windowService.open(url, '_blank');
   }
 
   deleteVersion(version: Version): void {


### PR DESCRIPTION
A small code change for adding a new row in the context menu for versions. This _should_ be the extent of the user interface changes for exporting versions.

To Do (WIP Tag) : As of this PR it's possible to test that the manifest has the correct version record, but I think it makes sense to do a more full test with a girder_wholetale PR for exporting particular versions & creating a version when one doesn't exist.

### Testing
The gist of the testing is to make sure that particular versions of a Tale are exporting. To test, create a few different versions of a Tale, each with different kinds of data (workspace/remote data).

1. While running `make rebuild_dashboard`, check the output to see that there aren't any new linter warnigns.
1. Create a new Tale
2. Add data to the workspace & remote data
3. Create a version
4. Delete or add more data to each of the folders above
5. Create a new version
6. In the context menu for the first version, select 'export'
7. Confirm that the exported Tale matches the first version
8. In the context menu for the second version, select 'export'
9. Confirm that the exported Tale matches the second version