### PR TITLE
temp fix: add "limit: 0" to most fetches to bypass Girder default

### DIFF
--- a/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts
@@ -62,8 +62,8 @@ export class SelectDataDialogComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.allDatasets = this.datasetService.datasetListDatasets({ myData: false });
-    this.datasets = this.myDatasets = this.datasetService.datasetListDatasets({ myData: true });
+    this.allDatasets = this.datasetService.datasetListDatasets({ myData: false, limit: 0 });
+    this.datasets = this.myDatasets = this.datasetService.datasetListDatasets({ myData: true, limit: 0 });
 
     const preAddedDatasets = this.data.tale.dataSet.map((ds: { itemId: string, mountPath: string, _modelType: string }) =>
       // Lookup the Dataset by id and push it to our selection
@@ -101,13 +101,13 @@ export class SelectDataDialogComponent implements OnInit {
   load(): void {
     if (this.currentFolderId) {
         // Fetch folders in the given folder
-      this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder })
+      this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder, limit: 0 })
                         .pipe(enterZone(this.zone))
                         .subscribe(folders => {
                           this.folders.next(folders);
                         });
         // Fetch items in the given folder
-      this.itemService.itemFind({ folderId: this.currentFolderId })
+      this.itemService.itemFind({ folderId: this.currentFolderId, limit: 0 })
                       .pipe(enterZone(this.zone))
                       .subscribe(items => {
                         this.files.next(items);
@@ -125,14 +125,14 @@ export class SelectDataDialogComponent implements OnInit {
       this.currentFolderId = this.selectedDataset._id;
 
       // Fetch folders in the workspace
-      this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder })
+      this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder, limit: 0 })
                         .pipe(enterZone(this.zone))
                         .subscribe(folders => {
                           this.folders.next(folders);
                         });
 
       // Fetch items in the workspace
-      this.itemService.itemFind({ folderId: this.currentFolderId })
+      this.itemService.itemFind({ folderId: this.currentFolderId, limit: 0 })
                       .pipe(enterZone(this.zone))
                       .subscribe(items => {
                         this.files.next(items);

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -261,13 +261,13 @@ export class TaleFilesComponent implements OnInit, OnChanges {
   load(): void {
     if (this.currentFolderId) {
         // Fetch folders in the given folder
-      this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder })
+      this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder, limit: 0 })
                         .pipe(enterZone(this.zone))
                         .subscribe(folders => {
                           this.folders.next(folders);
                         });
         // Fetch items in the given folder
-      this.itemService.itemFind({ folderId: this.currentFolderId })
+      this.itemService.itemFind({ folderId: this.currentFolderId, limit: 0 })
                       .pipe(enterZone(this.zone))
                       .subscribe(items => {
                         this.files.next(items);
@@ -284,14 +284,14 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         }
 
         // Fetch folders in the home folder
-        this.folderService.folderFind({ parentId: this.homeRoot._id, parentType: ParentType.Folder })
+        this.folderService.folderFind({ parentId: this.homeRoot._id, parentType: ParentType.Folder, limit: 0 })
                         .pipe(enterZone(this.zone))
                         .subscribe(folders => {
                           this.folders.next(folders);
                         });
 
         // Fetch items in the home folder
-        this.itemService.itemFind({ folderId: this.homeRoot._id })
+        this.itemService.itemFind({ folderId: this.homeRoot._id, limit: 0 })
                         .pipe(enterZone(this.zone))
                         .subscribe(items => {
                           this.files.next(items);
@@ -355,13 +355,13 @@ export class TaleFilesComponent implements OnInit, OnChanges {
           this.currentFolderId = this.tale.workspaceId;
 
           // Fetch folders in the workspace
-          this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder })
+          this.folderService.folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder, limit: 0 })
                             .subscribe(folders => {
                               this.zone.run(() => { this.folders.next(folders); });
                             });
 
           // Fetch items in the workspace
-          this.itemService.itemFind({ folderId: this.currentFolderId })
+          this.itemService.itemFind({ folderId: this.currentFolderId, limit: 0 })
                           .subscribe(items => {
                             this.zone.run(() => { this.files.next(items); });
                           });

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
@@ -86,7 +86,7 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
   }
 
   fetchUsers(): Promise<Array<User>> {
-    const userFetch = this.userService.userFind({}).toPromise();
+    const userFetch = this.userService.userFind({ limit: 0 }).toPromise();
     userFetch.then((users: Array<User>) => {
       users.forEach((user: User) => {
         user.name = `${user.firstName} ${user.lastName}`;

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -172,7 +172,7 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
     });
 
     // Fetch the list of public tales
-    const listTalesParams = {};
+    const listTalesParams = { limit: 0 };
     this.taleService.taleListTales(listTalesParams).subscribe((tales: Array<Tale>) => {
       // Filter based on search query
       this.tales = tales;

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -81,7 +81,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
     }
 
     // Fetch all Tale environment Images
-    const listImagesParams = {};
+    const listImagesParams = { limit: 0 };
     this.imageService.imageListImages(listImagesParams).subscribe(images => {
       this.zone.run(() => {
         this.environments = images;

--- a/src/app/api/models/sortdir.ts
+++ b/src/app/api/models/sortdir.ts
@@ -1,0 +1,4 @@
+export enum SortDir {
+  ASCENDING = 1,
+  DESCENDING = -1
+}

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.html
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.html
@@ -10,37 +10,12 @@
                 <span *ngIf="pathStack.length !== 2 || pathStack[0] !== wsRoot" title="{{currentRoot.name}}">
                     {{ currentRoot.name | truncate:headTruncateLength }}
                 </span>
-                <span *ngIf="pathStack.length === 2 && pathStack[0] === wsRoot && (currentRoot.name | taleName | async) as taleTitle"
-                      title="{{taleTitle}} ({{currentRoot.name}})">
-                    {{ taleTitle | truncate:headTruncateLength }}
-                </span>
               </span>
           </th>
         </thead>
 
-        <!-- If Workspaces is selected, translate taleIds into titles and show special tooltip -->
-        <tbody *ngIf="currentRoot && currentRoot === wsRoot && (folders | async).concat(files | async) as contents">
-          <tr *ngIf="!contents.length">{{ placeholderMessage }}</tr>
-          <tr [ngClass]="{
-                    'active': selectedFolder === elem,
-                    'clickable': elem._modelType === 'folder',
-                    'disabled not clickable': elem._modelType !== 'folder' || data.elementToMove._id === elem._id }"
-                *ngFor="let elem of contents; index as i; trackBy:trackById"
-                (click)="selectFolder(elem)"
-                (dblclick)="navigate(elem)">
-            <td>
-                <i class="fas fa-fw" [ngClass]="{
-                  'fa-folder': elem._modelType === 'folder',
-                  'fa-file': elem._modelType === 'item' || elem._modelType === 'file' }"></i>
-            </td>
-            <td *ngIf="(elem.name | taleName | async) as taleTitle" title="{{taleTitle}} ({{elem.name}})">
-                {{ taleTitle | truncate:bodyTruncateLength }}
-            </td>
-          </tr>
-        </tbody>
-
         <!-- If any other folder is selected, just display title as-is -->
-        <tbody *ngIf="currentRoot && currentRoot !== wsRoot && (folders | async).concat(files | async) as contents">
+        <tbody *ngIf="currentRoot && (folders | async).concat(files | async) as contents">
           <tr *ngIf="!contents.length">{{ placeholderMessage }}</tr>
           <tr [ngClass]="{
                 'active': selectedFolder === elem,

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
@@ -3,6 +3,7 @@ import { MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/d
 import { ActivatedRoute, Router } from '@angular/router';
 import { AccessLevel } from '@api/models/access-level';
 import { SortDir } from '@api/models/sortdir';
+import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
 import { CollectionService } from '@api/services/collection.service';
 import { DatasetService } from '@api/services/dataset.service';
@@ -170,20 +171,21 @@ export class MoveToDialogComponent implements OnInit {
       sortdir: SortDir.ASCENDING
     };
     if (this.currentFolderId === this.wsRoot._id) {
-      folderListParams.sort = 'updated';
-      folderListParams.sortdir = SortDir.DESCENDING;
-    }
-
-    // Fetch folders in the current folder
-    this.folderService
-      .folderFind(folderListParams)
-      .pipe(enterZone(this.zone))
-      .subscribe(folders => {
-        const filteredFolders = folders.filter((folder: FileElement) => {
-          return folder._accessLevel >= AccessLevel.Write; // Only show writeable
+      this.taleService
+        .taleListTales({ limit: 0, level: AccessLevel.Write, sortdir: SortDir.ASCENDING })
+        .pipe(enterZone(this.zone))
+        .subscribe(tales => {
+          this.folders.next(tales.map((tale: Tale) => new FileElement(tale, this.wsRoot)));
         });
-        this.folders.next(filteredFolders);
-      });
+    } else {
+      // Fetch folders in the current folder
+      this.folderService
+        .folderFind(folderListParams)
+        .pipe(enterZone(this.zone))
+        .subscribe(folders => {
+          this.folders.next(folders);
+        });
+    }
     // Fetch items in the current folder
     this.itemService
       .itemFind({ folderId: this.currentFolderId, limit: 0 })

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, NgZone, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
+import { AccessLevel } from '@api/models/access-level';
 import { User } from '@api/models/user';
 import { CollectionService } from '@api/services/collection.service';
 import { DatasetService } from '@api/services/dataset.service';
@@ -162,14 +163,17 @@ export class MoveToDialogComponent implements OnInit {
 
     // Fetch folders in the current folder
     this.folderService
-      .folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder })
+      .folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder, limit: 0 })
       .pipe(enterZone(this.zone))
       .subscribe(folders => {
-        this.folders.next(folders);
+        const filteredFolders = folders.filter((folder: FileElement) => {
+          return folder._accessLevel >= AccessLevel.Write; // Only show writeable
+        });
+        this.folders.next(filteredFolders);
       });
     // Fetch items in the current folder
     this.itemService
-      .itemFind({ folderId: this.currentFolderId })
+      .itemFind({ folderId: this.currentFolderId, limit: 0 })
       .pipe(enterZone(this.zone))
       .subscribe(items => {
         this.files.next(items);

--- a/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
+++ b/src/app/files/file-explorer/modals/move-to-dialog/move-to-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, NgZone, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AccessLevel } from '@api/models/access-level';
+import { SortDir } from '@api/models/sortdir';
 import { User } from '@api/models/user';
 import { CollectionService } from '@api/services/collection.service';
 import { DatasetService } from '@api/services/dataset.service';
@@ -161,9 +162,21 @@ export class MoveToDialogComponent implements OnInit {
       return;
     }
 
+    const folderListParams = {
+      parentId: this.currentFolderId,
+      parentType: ParentType.Folder,
+      limit: 0,
+      sort: 'lowerName',
+      sortdir: SortDir.ASCENDING
+    };
+    if (this.currentFolderId === this.wsRoot._id) {
+      folderListParams.sort = 'updated';
+      folderListParams.sortdir = SortDir.DESCENDING;
+    }
+
     // Fetch folders in the current folder
     this.folderService
-      .folderFind({ parentId: this.currentFolderId, parentType: ParentType.Folder, limit: 0 })
+      .folderFind(folderListParams)
       .pipe(enterZone(this.zone))
       .subscribe(folders => {
         const filteredFolders = folders.filter((folder: FileElement) => {

--- a/src/app/files/models/file-element.ts
+++ b/src/app/files/models/file-element.ts
@@ -1,3 +1,4 @@
+import { Tale } from '@api/models/tale';
 import { BaseDocument } from '~/app/framework/ngrx';
 
 export interface FileElement extends BaseDocument {
@@ -62,4 +63,23 @@ export class FileElement implements FileElement {
 
   // datasets only
   provider: string;
+
+  constructor(tale?: Tale, root?: FileElement) {
+    // allow to construct Workspace folder with a Tale name from Tale object
+    // the same trick could be later used for other aux folders.
+    if (tale) {
+      this._id = tale.workspaceId;
+      this._modelType = 'folder';
+      this.created = new Date(tale.created);
+      this.description = tale.description;
+      this.name = tale.title;
+      this.updated = new Date(tale.updated);
+      this.creatorId = tale.creatorId;
+      this.baseParentId = root.baseParentId;
+      this.baseParentType = root.baseParentType;
+      this._accessLevel = tale._accessLevel;
+      this.public = tale.public;
+      this.parentId = root._id;
+    }
+  }
 }


### PR DESCRIPTION
## Problem
Some fetched listings on https://dashboard.stage.wholetale.org are incomplete. Girder has a non-zero default `limit` set for these HTTP requests, so we are not getting the full list sent back.

This default behavior will be helpful later, when we consider adding paging to these views, but for now it is problematic.

Fixes #150 as a temporary workaround 

Long-term, we should look into adding paging to the controls where we expect this many results to be listed

## Approach
Set a `limit: 0` on each of the relevant fetches.

I basically did a grep for the word "list", and added a limit for most of the resulting calls:
```bash
$ grep -ir 'service' src/app | grep -v html | grep -v scss | grep -vi listener | grep -i list | grep -v src/app/api
src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts:      this.accountService.accountListTargets({ provider: this.data.provider.name }).subscribe(targets => {
src/app/+user-settings/configure-accounts/configure-accounts.component.ts:    this.accountService.accountListAccounts(params).subscribe((accts: Array<Account>) => {
src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts:    this.imageService.imageListImages(listImagesParams).subscribe(images => {
src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts:    this.tales$ = this.taleService.taleListTales(listTalesParams);
src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts:    this.instanceService.instanceListInstances(listInstancesParams).subscribe((instances: Array<Instance>) => {
src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts:    this.taleService.taleListTales(listTalesParams).subscribe((tales: Array<Tale>) => {
src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts:      this.tales$ = this.taleService.taleListTales(listTalesParams);
src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts:        this.tales$ = this.taleService.taleListTales({});
src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts:    this.allDatasets = this.datasetService.datasetListDatasets({ myData: false, limit: 0 });
src/app/+run-tale/run-tale/modals/select-data-dialog/select-data-dialog.component.ts:    this.datasets = this.myDatasets = this.datasetService.datasetListDatasets({ myData: true, limit: 0 });
src/app/+run-tale/run-tale/modals/tale-workspaces-dialog/tale-workspaces-dialog.component.ts:    this.taleService.taleListTales(params).subscribe((tales: Array<Tale>) => {
src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.ts:    this.repositoryService.repositoryListRepository().subscribe((repos: Array<Repository>) => {
src/app/+run-tale/run-tale/run-tale.component.ts:      this.instanceService.instanceListInstances(params).subscribe((instances: Array<Instance>) => {
src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts:    this.versionService.versionListVersions({ taleId: this.tale._id }).subscribe((versions: Array<Version>) => {
src/app/+run-tale/run-tale/tale-interact/tale-interact.component.ts:      this.instanceService.instanceListInstances(params)
src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts:    this.environments = this.imageService.imageListImages(params);
```

Note that "accounts" and "instances" have not had limits applied, as these likely won't scale over 100 entries. I can still go ahead and add them if we want some extra peace of mind there.

## How to Test
Prerequisites: lots and lots of test data (probably needs https://girder.stage.wholetale.org)

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. View the Tale Catalog and/or Data Catalog
    * You should see all entries listed here (e.g. datasets results should include names that start with F-Z) 
