### PR TITLE
fix: reorder / rename fields for consistency on Run > Metadata

### DIFF
--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -1,4 +1,31 @@
-<div class="ui stretched stackable grid" id="tale-metadata-container">
+
+<!--
+
+Fields Names / Order:
+    * Title
+    * (Read-only) Created By
+    * Authors
+    * Category
+    * Environment
+    * License
+    * Description
+    * (Edit only) Illustration
+    * (Read-only) Datasets Used
+    * (Read-only/conditional) Related Identifiers
+    * (Read-only) Published Location
+    * (Read-only) Date Created
+    * (Read-only) Last Updated
+
+
+
+
+-->
+
+
+
+
+
+<div class="ui stretched stackable grid" id="tale-metadata-container" *ngIf="tale">
   <div class="row">
     <div class="sixteen wide column">
 
@@ -15,8 +42,6 @@
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Authors</label>
           <div class="thirteen wide column" style="padding-left:0;">
-            <h4 style="text-align: center">Created by <span style="color:#67c096">{{ creator.firstName }} {{ creator.lastName }}</span></h4>
-
             <form id="taleAuthorsSubForm" #taleAuthorsSubForm="ngForm" class="ui form" *ngIf="_editState.authors.length">
               <table class="ui table striped condensed">
                 <tr>
@@ -56,6 +81,7 @@
           </div>
         </div>
 
+<!--
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Datasets used</label>
           <span *ngIf="!tale.dataSetCitation">No citable data</span>
@@ -67,6 +93,7 @@
               </li>
           </ul>
         </div>
+-->
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">License</label>
@@ -79,19 +106,23 @@
           </div>
         </div>
 
+<!--
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Date created</label>
           <div class="field thirteen wide column">
             <span>{{ _editState.created | date:'full' }}</span>
           </div>
         </div>
+-->
 
+<!--
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Last updated</label>
           <div class="field thirteen wide column">
             <span>{{ _editState.updated | date:'full' }}</span>
           </div>
         </div>
+-->
 
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Description</label>
@@ -115,7 +146,6 @@
           </div>
         </div>
 
-        <!-- TODO: "Generate" currently does nothing -->
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Illustration</label>
           <div class="ui action field thirteen wide column">
@@ -125,6 +155,7 @@
           </div>
         </div>
 
+<!--
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Published location</label>
           <div class="field thirteen wide column">
@@ -132,7 +163,7 @@
             <span *ngIf="latestPublish"><a [href]="latestPublish.uri">{{ latestPublish.pid }}</a></span>
           </div>
         </div>
-
+-->
         <div class="inline fields ui grid">
           <label class="two wide column right aligned"></label>
           <div class="field two wide right aligned column">
@@ -141,13 +172,6 @@
 
           <div class="field two wide right aligned column">
             <button class="ui button" (click)="cancelEdit()">Cancel</button>
-          </div>
-
-          <div class="field toggle ui checkbox four wide column">
-            <input type="checkbox" name="public"
-                [checked]="_editState.public"
-                (change)="_editState.public=!_editState.public">
-            <label>Public?</label>
           </div>
         </div>
 
@@ -167,17 +191,15 @@
         <div class="ten wide column">
           <div class="ui list">
             <div class="item">
-              <b>Category:</b>
-              <span class="category">{{ tale.category }}</span>
-            </div>
-            <div class="item">
               <b>Title:</b>
               <span>{{ tale.title }}</span>
             </div>
+
             <div class="item" *ngIf="creator">
               <b>Created By:</b>
               <span>{{ creator.firstName }} {{ creator.lastName }}</span>
             </div>
+
             <div class="item">
               <b>Authors:</b>
               <span *ngFor="let author of tale.authors; index as i; trackBy: trackById">
@@ -186,58 +208,74 @@
               <span *ngIf="!tale.authors.length && creator">{{ creator.firstName }} {{ creator.lastName }}</span>
               <span *ngIf="!tale.authors.length && !creator">???</span>
             </div>
+
             <div class="item">
-              <b>Description:</b>
-              <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+              <b>Category:</b>
+              <span class="category">{{ tale.category }}</span>
             </div>
+
+            <div class="item">
+              <b>Environment:</b>
+              <img *ngIf="tale.icon" class="ui image" [src]="tale.icon | safe:'url'" style="height:1.5em; margin:0 .4em; display: inline-block">
+              <span *ngIf="(tale | taleImage | async) as environment">{{ environment.name }}</span>
+            </div>
+
             <div class="item">
               <b>License:</b>
               <span>{{ tale.licenseSPDX }}</span>
             </div>
-            <div class="item">
-                <b>Published Location:</b>
-                <span *ngIf="latestPublish"><a [href]="latestPublish.uri">{{ latestPublish.pid }}</a></span>
-                <span *ngIf="!latestPublish">This Tale has not been published</span>
-            </div>
-            <div class="item spaced">
-              <b>Tale Specifics</b>
-              <div class="list">
-                <div class="item">
-                  <b>Tale ID</b>
-                  <span>{{ tale._id }}</span>
-                </div>
-                <div class="item">
-                  <b>Involatile Data:</b>
-                  <span *ngIf="!tale.dataSet.length">No citable data</span>
-                  <ul *ngIf="tale.dataSet.length">
-                    <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
-                        <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
-                    </li>
-                  </ul>
-                </div>
-                <div class="item">
-                  <b>Environment:</b>
 
-                  <img *ngIf="tale.icon" class="ui image" [src]="tale.icon | safe:'url'" style="height:1.5em; margin:0 .4em; display: inline-block">
-                  <span *ngIf="(tale | taleImage | async) as environment">{{ environment.name }}</span>
-                </div>
-                <div class="item">
-                  <b>Tale Created:</b>
-                  <span>{{ tale.created | date }}</span>
-                </div>
-                <div class="item">
-                  <b>Tale Updated:</b>
-                  <span>{{ tale.updated | date }}</span>
-                </div>
-                <div class="item" *ngIf="tale.relatedIdentifiers && tale.relatedIdentifiers.length">
-                  <b>Related Identifiers:</b>
-                  <ul>
-                    <li *ngFor="let ident of tale.relatedIdentifiers; index as i; trackBy: trackById">
-                        {{ ident.relation }} <a [href]="transformIdentifier(ident.identifier)" target="_blank">{{ ident.identifier }}</a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
+            <div class="item">
+              <b>Description:</b>
+              <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+            </div>
+
+<!--
+            <div class="item">
+                <b>Involatile Data:</b>
+                <span *ngIf="!tale.dataSet.length">No citable data</span>
+                <ul *ngIf="tale.dataSet.length">
+                <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
+                    <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
+                </li>
+                </ul>
+            </div>
+-->
+            <div class="item">
+              <b>Datasets Used:</b>
+              <span *ngIf="!tale.dataSetCitation.length">No citable data</span>
+              <ul *ngIf="tale.dataSetCitation.length" style="max-width:60vw">
+                <li *ngFor="let citation of tale.dataSetCitation">
+                    <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
+                        {{ citation }}
+                    </a>
+                </li>
+              </ul>
+            </div>
+
+            <div class="item" *ngIf="tale.relatedIdentifiers && tale.relatedIdentifiers.length">
+                <b>Related Identifiers:</b>
+                <ul>
+                <li *ngFor="let ident of tale.relatedIdentifiers; index as i; trackBy: trackById">
+                    {{ ident.relation }} <a [href]="transformIdentifier(ident.identifier)" target="_blank">{{ ident.identifier }}</a>
+                </li>
+                </ul>
+            </div>
+
+            <div class="item">
+              <b>Published Location:</b>
+              <span *ngIf="latestPublish"><a [href]="latestPublish.uri">{{ latestPublish.pid }}</a></span>
+              <span *ngIf="!latestPublish">This Tale has not been published</span>
+            </div>
+
+
+            <div class="item">
+                <b>Date Created:</b>
+                <span>{{ tale.created | date }}</span>
+            </div>
+            <div class="item">
+                <b>Last Updated:</b>
+                <span>{{ tale.updated | date }}</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Problem
Fields names / order are inconsistent between the rendered (read-only) and editable views for Run > Metadata.

Fixes #142 

## Approach
Move, reorder, and rename fields to match the order agreed upon in #142.

## How to Test
Prerequisites: at least one Tale created, at least one Dataset registered and attached to the Tale

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Metadata for a Tale that you own
    * You should see the following read-only fields (in order): Title, Created By, Authors, Category, Environment, License, Description, Datasets Used, Related Identifiers, Published Location, Date Created, Last Updated
4. Scroll to the bottom and click Edit
    * You should be brought to the editable view for Run > Metadata
    * You should see the following editable fields (in order): Title, Authors, Category, Environment, License, Description, Illustration