### PR TITLE
Double refresh on delete

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -1,6 +1,6 @@
 
 <!-- My Tales -->
-<div *ngIf="(tales$ | async) as taleList">
+<div *ngIf="tales.length">
 
     <!-- Search Tales -->
     <div class="row">
@@ -13,14 +13,14 @@
     </div>
 
   <!-- Running Tales -->
-  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="taleList"></app-running-tales>
+  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales"></app-running-tales>
 
-  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(taleList | myTales | stopped:instances) as allStoppedTales">
-    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchQuery:creators | myTales | stopped:instances) as filteredStoppedTales">
+  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(tales | myTales | stopped:instances) as allStoppedTales">
+    <div class="sixteen wide column" *ngIf="(tales | searchTales:searchQuery:creators | myTales | stopped:instances) as filteredStoppedTales">
 
       <!-- Placeholder Message -->
       <div class="ui message" *ngIf="!allStoppedTales.length">
-          You haven't created any Tales yet. Select the "Create New Tale" button above 
+          You haven't created any Tales yet. Select the "Create New Tale" button above
           or <a [routerLink]="'/public'">explore Tales created by other users</a>.
       </div>
 

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
@@ -1,6 +1,6 @@
 
 <!-- Public Tales -->
-<div *ngIf="(tales$ | async) as taleList">
+<div *ngIf="tales.length">
 
     <!-- Search Tales -->
     <div class="row">
@@ -13,10 +13,10 @@
     </div>
 
   <!-- Running Tales -->
-  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="taleList"></app-running-tales>
+  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales"></app-running-tales>
 
-  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(taleList | publicTales) as allPublicTales">
-    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchQuery:creators | publicTales) as filteredPublicTales">
+  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(tales | publicTales) as allPublicTales">
+    <div class="sixteen wide column" *ngIf="(tales | searchTales:searchQuery:creators | publicTales) as filteredPublicTales">
 
       <div class="ui message" *ngIf="!allPublicTales.length">
           No Public Tales have been shared.

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -25,7 +25,7 @@ declare var $: any;
   selector: 'app-public-tales'
 })
 export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
-  tales$: Observable<Array<Tale>> = new Observable<Array<Tale>>();
+  // tales$: Observable<Array<Tale>> = new Observable<Array<Tale>>();
   tales: Array<Tale> = [];
   publicTales: Array<Tale> = [];
 
@@ -71,7 +71,8 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
 
   ngOnInit(): void {
     const listTalesParams = {};
-    this.tales$ = this.taleService.taleListTales(listTalesParams);
+    // this.tales$ = this.taleService.taleListTales(listTalesParams);
+    this.refresh();
     this.userService.userGetMe().subscribe(user => {
       this.user = user;
     });
@@ -176,7 +177,7 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
     this.taleService.taleListTales(listTalesParams).subscribe((tales: Array<Tale>) => {
       // Filter based on search query
       this.tales = tales;
-      this.tales$ = this.taleService.taleListTales(listTalesParams);
+      // this.tales$ = this.taleService.taleListTales(listTalesParams);
       this.ref.detectChanges();
 
       // For each tale, also fetch its creator
@@ -201,6 +202,11 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
       const id = tale._id;
       this.taleService.taleDeleteTale({ id }).subscribe(response => {
         this.logger.debug("Successfully deleted Tale:", response);
+
+        const deletedTale = this.tales.find((t: Tale) => id === t._id);
+        const deletedIndex = this.tales.indexOf(deletedTale);
+        this.tales = this.tales.splice(deletedIndex);
+        this.ref.detectChanges();
       }, err => {
           this.logger.error("Failed to delete Tale:", err);
       });

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -204,7 +204,6 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
 
         // Explicitly force Tale list binding to refresh
         this.tales$ = this.taleService.taleListTales({});
-        this.refresh();
       }, err => {
           this.logger.error("Failed to delete Tale:", err);
       });

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -201,9 +201,6 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
       const id = tale._id;
       this.taleService.taleDeleteTale({ id }).subscribe(response => {
         this.logger.debug("Successfully deleted Tale:", response);
-
-        // Explicitly force Tale list binding to refresh
-        this.tales$ = this.taleService.taleListTales({});
       }, err => {
           this.logger.error("Failed to delete Tale:", err);
       });

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -199,9 +199,7 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
       this.taleService.taleDeleteTale({ id }).subscribe(response => {
         this.logger.debug("Successfully deleted Tale:", response);
 
-        const deletedTale = this.tales.find((t: Tale) => id === t._id);
-        const deletedIndex = this.tales.indexOf(deletedTale);
-        this.tales = this.tales.splice(deletedIndex, 1);
+        this.tales = this.tales.filter((t: Tale) => t._id !== id);
         this.ref.detectChanges();
       }, err => {
           this.logger.error("Failed to delete Tale:", err);

--- a/src/app/+tale-catalog/tale-catalog/components/shared-tales/shared-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/shared-tales/shared-tales.component.html
@@ -1,6 +1,6 @@
 
 <!-- Shared Tales -->
-<div *ngIf="(tales$ | async) as taleList">
+<div *ngIf="tales.length">
 
     <!-- Search Tales -->
     <div class="row">
@@ -13,11 +13,11 @@
     </div>
 
   <!-- Running Tales -->
-  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="taleList"></app-running-tales>
+  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales"></app-running-tales>
 
   <!-- Shared Tales -->
-  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(taleList | sharedTales | stopped:instances) as allStoppedTales">
-    <div class="sixteen wide column" *ngIf="(taleList | searchTales:searchQuery:creators | sharedTales | stopped:instances) as filteredStoppedTales">
+  <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(tales | sharedTales | stopped:instances) as allStoppedTales">
+    <div class="sixteen wide column" *ngIf="(tales | searchTales:searchQuery:creators | sharedTales | stopped:instances) as filteredStoppedTales">
 
       <!-- Placeholder Message -->
       <div class="ui message" *ngIf="!allStoppedTales.length">


### PR DESCRIPTION
**Problem**:
With the new event handling implementation, deleting a tale from the catalog results in a double refresh.

**Approach**:
Remove the refresh from the `openDeleteTaleModal` and rely on the tale removed event handling instead.

**Test**:
1. Create a tale
2. Return to dashboard
3. Delete the tale and confirm that the view is only refreshed once