### PR TITLE
Add "report a problem" button to the navbar

### DIFF
--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,10 +5,13 @@
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
-      <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/" target="_blank">
+      <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/" title="Users' Guide" target="_blank">
         <i class="info circle white icon"></i>
       </a>
-      <a class="item" (click)="toggleNotificationStream()">
+      <a class="item" href="https://github.com/whole-tale/whole-tale/issues" title="Report a Problem" target="_blank">
+        <i class="bug white icon"></i>
+      </a>
+      <a class="item" (click)="toggleNotificationStream()" title="Events and Notifications">
         <i class="tasks white icon"></i>
         <div id="event-notification-counter" class="floating ui red label" *ngIf="eventCount > 0">
             {{ eventCount }}

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -8,7 +8,7 @@
       <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/" title="Users' Guide" target="_blank">
         <i class="info circle white icon"></i>
       </a>
-      <a class="item" href="https://github.com/whole-tale/whole-tale/issues" title="Report a Problem" target="_blank">
+      <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" title="Report a Problem" target="_blank">
         <i class="bug white icon"></i>
       </a>
       <a class="item" (click)="toggleNotificationStream()" title="Events and Notifications">


### PR DESCRIPTION
## Problem
"Report a Problem" button went away when the footer was removed/hidden.

## Approach
* Add this functionality back in the navbar
* Add tooltips to pulled-right navbar links

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
    * You should see the "bug" icon in the navbar
3. Hover over the "bug" icon in the navbar (and Users' Guide / Notification buttons)
    * You should see a tooltip appear after a few seconds reading "Report a Problem"
4. Click the "bug" icon
    * You should see https://github.com/whole-tale/whole-tale/issues open in a new tab