### PR TITLE
Default selection to Tale Workspace

### DIFF
--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -81,7 +81,7 @@ export class TaleFilesComponent implements OnInit, OnChanges {
   currentPath = '';
   canNavigateUp = false;
 
-  currentNav = 'external_data';
+  currentNav = 'tale_workspace';
 
   constructor(
     private ref: ChangeDetectorRef,


### PR DESCRIPTION
**Problem**:
I expect users will more often interact with the Tale Workspace than External Data.

**Approach:**
This PR sets the Tale Workspace as the default selection on the Files panel

**Test:**
* Create or open an existing tale
* Select the files tab
* Note that Tale Workspace is selected by default