### PR TITLE
fix: make notification ack button stand out

### DIFF
--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -51,7 +51,7 @@
     </tr>
   </table>
 
-  <button class="fluid ui positive button" (click)="ackAll()">Acknowledge all</button>
+  <button class="ui tiny positive left floated button" (click)="ackAll()">Acknowledge all</button>
 </div>
 
 

--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -51,7 +51,7 @@
     </tr>
   </table>
 
-  <button class="ui button" (click)="ackAll()">Acknowledge all</button>
+  <button class="fluid ui positive button" (click)="ackAll()">Acknowledge all</button>
 </div>
 
 

--- a/src/app/layout/notification-stream/notification-stream.component.scss
+++ b/src/app/layout/notification-stream/notification-stream.component.scss
@@ -1,6 +1,7 @@
 #notificationStream {
   position: fixed;
   background: lightgrey;
+  border: 1px solid rgba(34, 36, 38, 0.15);
   top: 50px;
   right: 20px;
   max-height: 40vh;


### PR DESCRIPTION
## Problem

Fixes whole-tale/whole-tale#92

## Approach
Make it green (positive) button. I can be talked out of "fluid" in favor of "floated right".

## How to Test

1. Deploy
2. Click on notification panel and see how it looks and feels without any message
3. Create a Tale and build image
4. See how notification panel looks and feels.