### PR TITLE
Add configurable documentation URL

### DIFF
--- a/src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.html
@@ -11,7 +11,7 @@
   </p>
 
   <p>For more information on how to publish and cite your Tale, please consult the
-    <a href="https://wholetale.readthedocs.io/en/stable/users_guide/publishing.html" target="_blank">
+    <a [href]="docUrl" target="_blank">
       Publishing Guide
     </a>.
   </p>
@@ -31,7 +31,7 @@
     Publishing creates an immutable copy of your
     Tale with a DOI. For more information on publishing
     and citing your Tale, please consult the
-    <a href="https://wholetale.readthedocs.io/en/stable/users_guide/publishing.html" target="_blank">
+    <a [href]="docUrl" target="_blank">
       Publishing Guide
     </a>.
   </p>

--- a/src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/publish-tale-dialog/publish-tale-dialog.component.ts
@@ -9,6 +9,8 @@ import { JobService } from '@api/services/job.service';
 import { RepositoryService } from '@api/services/repository.service';
 import { TaleService } from '@api/services/tale.service';
 import { LogService } from '@framework/core/log.service';
+import { WindowService } from '@framework/core/window.service';
+
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -43,6 +45,7 @@ export class PublishTaleDialogComponent implements OnInit {
     private readonly taleService: TaleService,
     private readonly jobService: JobService,
     private readonly logger: LogService,
+    private readonly window: WindowService,
     @Inject(MAT_DIALOG_DATA) public data: { tale: Tale }) {
 
   }
@@ -174,5 +177,9 @@ export class PublishTaleDialogComponent implements OnInit {
       this.publishStatus = 'error';
       this.lastMessage = err.error.message || 'Failed to submit publishing job';
     });
+  }
+
+  get docUrl(): string {
+    return this.window.env.rtdBaseUrl + "/users_guide/publishing.html";
   }
 }

--- a/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.html
@@ -27,7 +27,7 @@
               The URL or DOI of the data object. Data packages can be imported into WholeTale from 
 	      <a href="https://www.dataone.org" target="_blank">DataONE</a>, <a href="https://dataverse.org/" target="_blank">Dataverse</a>, <a href="https://zenodo.org/" target="_blank">Zenodo</a> and select <a href="https://www.globus.org" target="_blank">Globus</a> 
               repositories. For a full list of DataONE member nodes and supported Globus repositories, visit the 
-              <a href="https://wholetale.readthedocs.io/en/stable/users_guide/manage.html#supported-data-repositories" target="_blank">data registration guide</a>.
+              <a [href]="docUrl" target="_blank">data registration guide</a>.
             </p>
           </div>
 

--- a/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/register-data-dialog/register-data-dialog.component.ts
@@ -63,4 +63,8 @@ export class RegisterDataDialogComponent {
   activateNav(nav: string): void {
     this.selectedNav = nav;
   }
+
+  get docUrl(): string {
+    return this.window.env.rtdBaseUrl + "/users_guide/manage.html#supported-data-repositories";
+  }
 }

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -386,8 +386,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     }
 
     gotoDocs(): void {
-      // TODO: how to avoid hard-coding this link?
-      this.windowService.open("https://wholetale.readthedocs.io/en/stable/users_guide/run.html", '_blank');
+      this.windowService.open(this.windowService.env.rtdBaseUrl + '/users_guide/run.html', '_blank');
     }
 
     exportTale(format: TaleExportFormat = TaleExportFormat.BagIt): void {

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
@@ -40,7 +40,7 @@
             <label>
                 <b>READ ONLY</b>
                 <i style="margin-left:5px;">recommended</i> — Treat as source dataset for analysis
-                <a href="https://docs.wholetale.org/en/stable/users_guide/compose.html"
+                <a [href]="docUrl"
                    style="margin-left: .75rem;font-style:italic" target="_blank">Why would I do this?</a>
             </label>
         </div>

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -4,6 +4,7 @@ import { Image } from '@api/models/image';
 import { Tale } from '@api/models/tale';
 import { ImageService } from '@api/services/image.service';
 import { LogService } from '@framework/core/log.service';
+import { WindowService } from '@framework/core/window.service';
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -27,7 +28,8 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       public dialogRef: MatDialogRef<CreateTaleModalComponent>,
       @Inject(MAT_DIALOG_DATA) public data: { params: any, showGit: boolean },
       private imageService: ImageService,
-      private logger: LogService
+      private logger: LogService,
+      private readonly window: WindowService
     ) {
     this.newTale = {
       title: (data && data.params) ? data.params.name : '',
@@ -121,5 +123,9 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
 
   trackById(index: number, env: Image): string {
     return env._id;
+  }
+
+  get docUrl(): string {
+    return this.window.env.rtdBaseUrl + "/users_guide/compose.html";
   }
 }

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,7 +5,7 @@
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
-      <a class="item" href="https://wholetale.readthedocs.io/en/stable/users_guide/" title="Users' Guide" target="_blank">
+      <a class="item" [href]="docUrl" title="Users' Guide" target="_blank">
         <i class="info circle white icon"></i>
       </a>
       <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" title="Report a Problem" target="_blank">

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -11,6 +11,7 @@ import { ConfigService } from '@ngx-config/core';
 import { CookieService } from 'ngx-cookie-service';
 import { Observable } from 'rxjs';
 import { Language, LanguageSelectors, State } from '~/app/store';
+import { WindowService } from '@framework/core/window.service';
 
 import { NotificationStreamService } from './notification-stream/notification-stream.service';
 
@@ -48,7 +49,8 @@ export class HeaderComponent extends BaseComponent implements OnInit {
     private readonly cookies: CookieService,
     private readonly users: UserService,
     private readonly tokenService: TokenService,
-    private readonly notificationStream: NotificationStreamService
+    private readonly notificationStream: NotificationStreamService,
+    private readonly window: WindowService
   ) {
     super();
 
@@ -67,6 +69,7 @@ export class HeaderComponent extends BaseComponent implements OnInit {
     this.availableLanguages = this.config.getSettings('i18n.availableLanguages');
     this.isAuthenticated = this.auth.isAuthenticated;
     this.user = this.tokenService.user;
+
 
     this.zone.runOutsideAngular(() => {
       $('.ui.account.dropdown').dropdown({ action: 'hide' });
@@ -102,5 +105,9 @@ export class HeaderComponent extends BaseComponent implements OnInit {
     }
 
     return this.events.length;
+  }
+
+  get docUrl(): string {
+    return this.window.env.rtdBaseUrl + "/users_guide";
   }
 }

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -20,7 +20,7 @@
   </a>
 
   <p style="botmargin" style="margin: 10px; color:black;">By accessing Whole Tale, you agree to our
-    <a href="https://docs.wholetale.org/tos" style="color:black"><u>Terms of Use</u></a>.
+    <a [href]="tosUrl" style="color:black" target="_blank"><u>Terms of Use</u></a>.
   </p>
 
   <div style="color:black">

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -131,4 +131,8 @@ export class LoginComponent extends BaseComponent implements OnInit {
 
     return auth$;
   }
+
+  get tosUrl(): string {
+    return this.window.env.rtdBaseUrl + "/tos";
+  }
 }

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -5,4 +5,5 @@
   window.env.apiUrl = '${GIRDER_API_URL}';
   window.env.dataONEBaseUrl = '${DATAONE_URL}';
   window.env.authProvider = '${AUTH_PROVIDER}';
+  window.env.rtdBaseUrl = '${RTD_URL}';
 })(this);


### PR DESCRIPTION
Fixes #163 

## Problem
Documentation URLs are hardcoded, pointing to stable

## Approach
Add new env var `RTD_URL` that is used as a base URL in the creation of documentation links.

## How to Test

Deploy with https://github.com/whole-tale/deploy-dev/pull/48

1. Checkout this branch locally, rebuild the dashboard
2. Goto https://dashboard.local.wholetale.org/login, confirm TOS URL points to https://wholetale.readthedocs.io/en/latest/tos
3. Goto https://girder.local.wholetale.org/api/v1/integration/dataverse?datasetPid=doi%3A10.7910%2FDVN%2F3MJ7IR&siteUrl=https%3A%2F%2Fdataverse.harvard.edu, confirm "Why would I do this" points to latest
3. Check header "i", Tale > Read the docs, Publish, register data
