### PR TITLE
Added original/copy indicator on public tales

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
@@ -30,6 +30,11 @@
 
         <!-- Card for each Tale -->
         <div class="ui card" *ngFor="let tale of filteredPublicTales; index as i; trackBy: trackById">
+          <div class="extra content">
+            <span style="text-transform:uppercase">
+              {{ tale.copyOfTale ? 'copy' : 'original' }}
+            </span>
+          </div>
           <div class="blurring dimmable segment fluid image" id="{{ tale._id }}-dimmer" (mouseover)="showDimmer(tale)" (mouseout)="hideDimmer(tale)">
 
             <!-- Abstract card into reusable template? Card component? -->


### PR DESCRIPTION
## Problem

In the quickstart documentation, we instruct users to copy-on-launch the LIGO tale. However, on production there are now 3 public LIGO tales -- which one should they use?

## Approach
This PR adds the original/copy indicator to public tales

<img width="1171" alt="Screen Shot 2021-04-16 at 3 18 17 PM" src="https://user-images.githubusercontent.com/4334350/115074297-84492a00-9ec7-11eb-8e90-634ef3888218.png">

## How to Test
* Deploy this PR
* Register LIGO tale
* Copy-on-launch LIGO tale and set to public
* Goto Public Tales tab and confirm that copy/original display


