### PR TITLE
Remove padding around iframe

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -1,5 +1,5 @@
 <div fxFlex fxLayout="row" fxLayoutAlign="space-between stretch" [@routeAnimation]>
-    <div class="ui stretched stackable grid panel-container" *ngIf="tale">
+    <div class="ui stackable grid panel-container" *ngIf="tale">
         <div class="row">
             <div class="sixteen wide column">
 

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -157,13 +157,19 @@ app-tale-versions-panel {
   height: 100%;
 }
 
+.wt_panel_body > .ui.grid,
+.wt_panel_body > .ui.grid > .row,
+.wt_panel_body > .ui.grid > .row > .column {
+  margin: 0;
+  padding: 0;
+}
+
 .ui.grid {
   height: 100%;
 }
 
 .wt-panel .wt-panel-body {
-  padding: 2rem 2rem 0 2rem;
-  height: 82%;
+  height: 88%;
 }
 .wt-panel .wt-panel-body.bg-grey,
 .wt-panel .wt-panel-header.bg-grey {

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -14,6 +14,7 @@
 
 :host {
   min-height: 95%;
+  margin: 12pt 0 0 0;
 }
 
 .ui.breadcrumb a {
@@ -154,18 +155,28 @@ app-tale-versions-panel {
   margin-top: 1rem;
 }
 .wt-panel .wt-panel-body .ui.grid .row .wide.column > div {
-  height: 100%;
+  height: 99.4%;
 }
 
 .wt_panel_body > .ui.grid,
 .wt_panel_body > .ui.grid > .row,
 .wt_panel_body > .ui.grid > .row > .column {
+  height: 100%;
   margin: 0;
   padding: 0;
 }
 
 .ui.grid {
   height: 100%;
+}
+
+.wt-panel > .wt-panel-body > .row {
+  padding-bottom: 0 !important;
+}
+
+.ui.stretched.stackable.grid.panel-container {
+  height: 100%;
+  height: auto;
 }
 
 .wt-panel .wt-panel-body {

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.scss
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.scss
@@ -9,6 +9,41 @@
   //overflow-y: auto;
 }
 
+.four.wide.column {
+  padding-right: 0;
+}
+
+.ui.grid > .row > .stretched.column > *,
+.ui.grid > .stretched.column:not(.row) > *,
+.ui.grid > .stretched.row > .column > *,
+.ui.stretched.grid > .column > *,
+.ui.stretched.grid > .row > .column > * {
+  flex-grow: unset;
+}
+
+.twelve.wide.column > .ui.segment {
+  border-radius: 0 0 10pt 0;
+  box-shadow: none;
+}
+
+.ui.message {
+  border-radius: 0 0 10pt 0;
+  box-shadow: none;
+}
+
+.ui.segment {
+  border: none;
+  padding: 0;
+  height: 100%;
+}
+
+.four.wide.column,
+.twelve.wide.column {
+  padding-top: 0;
+  padding-left: 0;
+  padding-bottom: 0;
+}
+
 .ui.grid {
   height: 100%;
 }

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.scss
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.scss
@@ -9,6 +9,14 @@
   height: 100%;
 }
 
+.ui.grid > .row {
+  padding-top: 0;
+}
+
+.ui.grid > .row > .column {
+  padding-left: 0;
+}
+
 .status-banner {
   margin-top: 10vh;
   text-align: center;
@@ -23,4 +31,8 @@
   height: 60vh;
   text-align: center;
   padding-top: 15vh;
+}
+
+iframe {
+  border: none;
 }

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.scss
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.scss
@@ -1,6 +1,7 @@
 #tale-metadata-container {
   //min-height: 60vh;
   height: 100%;
+  padding: 2rem 2rem 0 2rem;
 }
 
 #readOnlyMetadata .item > span {

--- a/src/app/files/file-explorer/file-explorer.component.scss
+++ b/src/app/files/file-explorer/file-explorer.component.scss
@@ -10,10 +10,15 @@
   user-select: none;
 }
 
+mat-toolbar {
+  border-bottom: lightgrey 1px solid;
+}
+
 .ui.message {
   width: 100%;
   max-width: none;
-  border-radius: 0;
+  border-radius: 0 0 10pt 0;
+  box-shadow: none;
 }
 
 .toolbar {


### PR DESCRIPTION
## Problem
There is a bunch of extra padding around the `iframe` on Run Tale > Interact. This makes it difficult to use the view within the `iframe`, as there is not much space to see.

Fixes #168 ?

## Approach
* Remove as much padding as possible from around the iframe without disturbing other parts of the UI.
* Add the same padding values back to Run Tale > Metadata

<img width="1676" alt="Screen Shot 2021-04-26 at 3 49 57 PM" src="https://user-images.githubusercontent.com/1413653/116149156-69d13680-a6a7-11eb-84c7-00165935f624.png">

Note that the bottom of the panel is a special case - because of the unique scrolling behavior and how painful it is/was to tweak those margins across all views. If we are ok with the panel stretching off the bottom of the page, then we can revisit this.

Also, please ignore the broken/fake login screen here (WT hates that I use `localhost:4200` for development and throws security errors, as mentioned in the dev meeting)

## How to Test
Prerequisites: at least one Tale running

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run Tale > Interact for a running Tale
    * You should see the iframe now appears flush against the tab bar at the top, as well as the panel borders on the left and right
