### PR TITLE
Don't spawn Tale with AiWT

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -66,7 +66,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
                 imageId: tale.imageId, // Pull from user input
                 asTale: asTale ? asTale : false, // Pull from user input
                 git: result.url ? true : false,
-                spawn: true, // if true, immediately launch a Tale instance
+                spawn: false, // if true, immediately launch a Tale instance
                 taleKwargs: tale.title ? { title: tale.title } : {}, 
                 lookupKwargs: {},
               };


### PR DESCRIPTION
## Problem
Tale is launched after importing with AiWT.

## Approach
Pass `spawn=false` to prevent Tale from being automatically launched.

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to https://girder.stage.wholetale.org/api/v1/integration/dataverse?datasetPid=doi%3A10.7910%2FDVN%2F3MJ7IR&siteUrl=https%3A%2F%2Fdataverse.harvard.edu
    * You should be redirected to the dashboard
    * You should see the Create Tale modal appear
    * You should see that "Create New Tale" is not enabled at the bottom
4. Enter a title and select an Environment
    * You should see now that "Create New Tale" is enabled
5. Click "Create New Tale"
    * You should be redirected to the Run view
    * You should **not** see the Tale automatically launch