### PR TITLE
fix: make 'Get token from url' for API keys dynamical

### DIFF
--- a/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.html
+++ b/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.html
@@ -23,7 +23,7 @@
           </div>
           <div class="field">
             <label>API Token
-                <a *ngIf="data.provider.docs_href" href="{{ data.provider.docs_href }}" style="float:right; font-weight:normal" target="_blank">Get from {{ data.provider.fullName }} <i class="external square alternate icon"></i></a>
+              <a *ngIf="newApiKey.resource_server" href="{{ getToken() }}" style="float:right; font-weight:normal" target="_blank">Get from {{ data.provider.fullName }} <i class="external square alternate icon"></i></a>
             </label>
             <input type="text" name="API Token" placeholder="Enter an API key" [(ngModel)]="newApiKey.access_token" />
           </div>

--- a/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.html
+++ b/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.html
@@ -23,7 +23,7 @@
           </div>
           <div class="field">
             <label>API Token
-              <a *ngIf="newApiKey.resource_server" href="{{ getToken() }}" style="float:right; font-weight:normal" target="_blank">Get from {{ data.provider.fullName }} <i class="external square alternate icon"></i></a>
+              <a *ngIf="newApiKey.resource_server" href="{{ getTokenUrl() }}" style="float:right; font-weight:normal" target="_blank">Get from {{ data.provider.fullName }} <i class="external square alternate icon"></i></a>
             </label>
             <input type="text" name="API Token" placeholder="Enter an API key" [(ngModel)]="newApiKey.access_token" />
           </div>

--- a/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
+++ b/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
@@ -67,7 +67,7 @@ export class ConnectApiKeyModalComponent extends BaseComponent implements OnInit
       return target;
   }
 
-  getToken(): string {
+  getTokenUrl(): string {
     return this.data.provider.docs_href.replace(/{siteUrl}/g, this.newApiKey.resource_server);
   }
 }

--- a/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
+++ b/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
@@ -66,4 +66,8 @@ export class ConnectApiKeyModalComponent extends BaseComponent implements OnInit
   trackByTarget(index: number, target: string): string {
       return target;
   }
+
+  getToken(): string {
+    return this.data.provider.docs_href.replace("{siteUrl}", this.newApiKey.resource_server);
+  }
 }

--- a/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
+++ b/src/app/+user-settings/modals/connect-apikey-modal/connect-apikey-modal.component.ts
@@ -68,6 +68,6 @@ export class ConnectApiKeyModalComponent extends BaseComponent implements OnInit
   }
 
   getToken(): string {
-    return this.data.provider.docs_href.replace("{siteUrl}", this.newApiKey.resource_server);
+    return this.data.provider.docs_href.replace(/{siteUrl}/g, this.newApiKey.resource_server);
   }
 }


### PR DESCRIPTION
## Problem

`docs_href` in connect api_key account was hardcoded, but it would be nice if it took `resource_server` into account.

## Approach
Solves the problem by using a template string. Only show href if resource_server is selected.

## How to Test

1. Checkout this branch locally, rebuild the dashboard (needs https://github.com/whole-tale/girder_wholetale/pull/479)
2. Login to the WholeTale Dashboard
3. Go to settings page
4. Select Dataone.
5. Select one of the CNs.
6. Follow "Get from DataONE"
7. Confirm you get a token.
