### PR TITLE
Added handling for wt_instance_error

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -55,6 +55,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     taleUnsharedSubscription: Subscription;
     taleInstanceLaunchingSubscription: Subscription;
     taleInstanceRunningSubscription: Subscription;
+    taleInstanceErrorSubscription: Subscription;
 
     constructor(
       private ref: ChangeDetectorRef,
@@ -225,6 +226,15 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         }
       });
 
+      this.taleInstanceErrorSubscription = this.syncService.instanceErrorSubject.subscribe((resource: {taleId: string, instanceId: string}) => {
+        if (resource.taleId === this.taleId) {
+          this.instanceService.instanceGetInstance(resource.instanceId).subscribe((instance: Instance) => {
+            this.instance = instance;
+            this.ref.detectChanges();
+          });
+        }
+      });
+
       this.taleUnsharedSubscription = this.syncService.taleUnsharedSubject.subscribe((taleId) => {
         if (taleId === this.taleId) {
           // Update current collaborators list
@@ -311,6 +321,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.taleUnsharedSubscription.unsubscribe();
       this.taleInstanceLaunchingSubscription.unsubscribe();
       this.taleInstanceRunningSubscription.unsubscribe();
+      this.taleInstanceErrorSubscription.unsubscribe();
     }
 
     performRecordedRun(): void {

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.ts
@@ -41,6 +41,7 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
 
   instanceLaunchingSubscription: Subscription;
   instanceRunningSubscription: Subscription;
+  instanceErrorSubscription: Subscription;
 
   AccessLevel: any = AccessLevel;
 
@@ -107,6 +108,9 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
     this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe((resource: { taleId: string, instanceId: string }) => {
       this.refresh();
     });
+    this.instanceErrorSubscription = this.syncService.instanceErrorSubject.subscribe((resource: { taleId: string, instanceId: string }) => {
+      this.refresh();
+    });
   }
 
   ngOnChanges(): void {
@@ -127,6 +131,7 @@ export class PublicTalesComponent implements OnChanges, OnInit, OnDestroy {
 
     this.instanceLaunchingSubscription.unsubscribe();
     this.instanceRunningSubscription.unsubscribe();
+    this.instanceErrorSubscription.unsubscribe();
   }
 
   taleInstanceStateChanged(updated: {tale: Tale, instance: Instance}): void {

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -69,6 +69,8 @@ export class NotificationStreamComponent {
 
     // FIXME: this should use `eventData.type` instead, or adjust wt_progress + others
     // Handle resource-specific updates
+
+    this.logger.info('Processing event: ' + event);
     switch (event) {
       case 'wt_tale_updated':
         return this.sync.taleUpdated(affectedResourceIds.taleId);
@@ -93,8 +95,10 @@ export class NotificationStreamComponent {
         return this.sync.instanceLaunching(affectedResourceIds.taleId, affectedResourceIds.instanceId);
       case 'wt_instance_running':
         return this.sync.instanceRunning(affectedResourceIds.taleId, affectedResourceIds.instanceId);
+      case 'wt_instance_error':
+        return this.sync.instanceError(affectedResourceIds.taleId, affectedResourceIds.instanceId);
       default:
-        this.logger.info('Unrecognized update event: ' + event);
+        this.logger.info('Unrecognized update event: ' + girderEvent.data);
         break;
     }
 

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -31,6 +31,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
 
   instanceLaunchingSubscription: Subscription;
   instanceRunningSubscription: Subscription;
+  instanceErrorSubscription: Subscription;
 
   constructor(
     private readonly ref: ChangeDetectorRef,
@@ -69,6 +70,19 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
         });
       }
     );
+    this.instanceErrorSubscription = this.syncService.instanceErrorSubject.subscribe(
+      (resource: { taleId: string; instanceId: string }) => {
+        // Ignore updates that aren't for this Tale
+        if (resource.taleId != this.tale._id) {
+          return;
+        }
+
+        this.instanceService.instanceGetInstance(resource.instanceId).subscribe((instance: Instance) => {
+          this.instance = instance;
+          this.ref.detectChanges();
+        });
+      }
+    );
   }
 
   ngOnChanges(): void {
@@ -80,6 +94,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.instanceLaunchingSubscription.unsubscribe();
     this.instanceRunningSubscription.unsubscribe();
+    this.instanceErrorSubscription.unsubscribe();
   }
 
   autoRefresh(): void {

--- a/src/app/tales/sync.service.ts
+++ b/src/app/tales/sync.service.ts
@@ -19,6 +19,7 @@ export class SyncService {
 
   readonly instanceLaunchingSubject = new Subject<{ taleId: string; instanceId: string }>();
   readonly instanceRunningSubject = new Subject<{ taleId: string; instanceId: string }>();
+  readonly instanceErrorSubject = new Subject<{ taleId: string; instanceId: string }>();
 
   constructor(private readonly logger: LogService) {}
   taleCreated(taleId: string): void {
@@ -50,6 +51,10 @@ export class SyncService {
   instanceRunning(taleId: string, instanceId: string): void {
     this.logger.info('Updating Instance via SyncService: ', instanceId);
     this.delay(() => this.instanceRunningSubject.next({ taleId, instanceId }));
+  }
+  instanceError(taleId: string, instanceId: string): void {
+    this.logger.info('Updating Instance via SyncService: ', instanceId);
+    this.delay(() => this.instanceErrorSubject.next({ taleId, instanceId }));
   }
 
   // TODO: Indicate Tale import state in UI


### PR DESCRIPTION
## Problem

UI does not currently handle `wt_instance_error` notification

## Approach

Bold C&P from `wt_instance_running` implementation

## How to Test

* Depends on https://github.com/whole-tale/gwvolman/pull/145 and https://github.com/whole-tale/girder_wholetale/pull/480
* Modify `setup_girder.py` to set the command for JupyterLab to something that doesn't exist (e.g., `thisdoesnotexist`)
* `make clean && make dev`
* Create  JupyterLab tale and Run
* Note progression of notifications (building image, creating volume, starting container)
* Job should fail with "Error: starting container"
* View logs, note stack trace about executable not on PATH
* Run button should change to "Error!" and "Tale launching" > "Something went wrong."
