### PR TITLE
Fix dataset and DOI links

### DIFF
--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -246,7 +246,7 @@ Fields Names / Order:
               <span *ngIf="!tale.dataSetCitation.length">No citable data</span>
               <ul *ngIf="tale.dataSetCitation.length" style="max-width:60vw">
                 <li *ngFor="let citation of tale.dataSetCitation">
-                    <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files' }" routerLinkActive="active" queryParamsHandling="merge">
+                    <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files', nav: 'external_data' }" routerLinkActive="active" queryParamsHandling="merge">
                         {{ citation }}
                     </a>
                 </li>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -196,7 +196,7 @@ export class TaleMetadataComponent implements OnInit {
 
   transformIdentifier(identifier: string): string {
     if (identifier.indexOf('doi:') === 0) {
-      return identifier.replace('doi:', 'doi.org/');
+      return identifier.replace('doi:', 'https://doi.org/');
     }
 
     return identifier;


### PR DESCRIPTION
## Problems

* DOI links in related identifiers are relative to dashboard because of missing protocol
* Datasets Used links go to Tale Workspace instead of External Data

## Approach
* Prefix DOI urls with `https://`
* Datasets Used links go to External Data

## How to Test

* Create a tale
* Register and add a dataset, e.g.:
  * ~DataONE: doi:10.18739/A2CN6XZ7H~
  * DVN: doi:10.7910/DVN/SZ9YXZ
  * Zenodo: doi:10.5281/zenodo.16384
  * MDF: doi:10.18126/M2301J
* Go to Metadata page
* Confirm Related Identifier links work as expected
* Confirm Datasets Used links go to File > External Data