### PR TITLE
feat: add progress indicator for file uploads

### DIFF
--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -56,7 +56,13 @@
         <th class="center aligned"><i class="fas fa-fw fa-2x {{ getIcon(ele) }}"></i></th>
         <td [title]="ele.name">{{ ele.name | truncate:100 }}</td>
         <td [title]="ele.updated">{{ ele.updated | date }}</td>
-        <td class="right aligned" [title]="ele.size">{{ ele.size | fileSize }}</td>
+        <td class="right aligned" [title]="ele.size">
+            <small *ngIf="ele.uploading">Uploading... {{ ele.uploadProgress | number }}%</small>
+            <div *ngIf="ele.uploading" [id]="'upload-' + ele._id" class="ui indicating progress" data-percent="0">
+                <div class="bar"></div>
+            </div>
+            {{ ele.size | fileSize }}
+        </td>
         <td class="center aligned">
           <div id="more-actions-{{ ele._id }}" class="ui inline file dropdown" (click)="openMenu($event, ele)" *ngIf="showContextMenu">
             <!--<div class="text">More</div>-->

--- a/src/app/files/file-explorer/file-explorer.component.scss
+++ b/src/app/files/file-explorer/file-explorer.component.scss
@@ -30,6 +30,16 @@ mat-toolbar {
   overflow: hidden;
 }
 
+.ui.progress {
+  height: 4px;
+  margin: 0;
+  padding: 0;
+}
+
+.ui.progress > .bar {
+  height: 4px;
+}
+
 .file-or-folder-icon {
   width: 50px;
   height: 50px;

--- a/src/app/files/filesize.pipe.ts
+++ b/src/app/files/filesize.pipe.ts
@@ -7,7 +7,7 @@ export class FileSizePipe implements PipeTransform {
 
   transform(value: number): string {
     if (!value) {
-      return '';
+      return '0 B';
     }
 
     let val = JSON.parse(JSON.stringify(value));

--- a/src/app/files/models/file-element.ts
+++ b/src/app/files/models/file-element.ts
@@ -11,6 +11,10 @@ export interface FileElement extends BaseDocument {
   size: number;
   updated: Date;
 
+  // upload progress
+  uploadProgress: number;
+  uploading: boolean;
+
   // present only on folders, items, and datasets
   creatorId: string;
 
@@ -42,6 +46,10 @@ export class FileElement implements FileElement {
   name: string;
   size = 0;
   updated: Date = new Date();
+
+  // upload progress
+  uploadedBytes = 0;
+  uploading = false;
 
   // present only on folders, items, and datasets
   creatorId: string;


### PR DESCRIPTION
## Problem
File uploads do not show their progress

Fixes #167 

## Approach
* Add a basic progress bar that shows a simple percentage (no estimated time or granular byte count, nothing fancy)

## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run Tale > Files
4. Upload a File (larger than 200MB or so)
    * You should see a progress bar and percentage now appear above the file Size as it uploads
5. Wait for the file to finish uploading
    * You should see the progress bar update over time
    * You should see the progress bar disappear once the file upload is complete 
