### PR TITLE
feat: indicate tale import status via the Run button

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -51,8 +51,9 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     collaborators: { users: Array<User>, groups: Array<User> } = { users: [], groups: [] };
 
     removeSubscription:Subscription;
-    subscription: Subscription;
+    updateSubscription: Subscription;
     taleUnsharedSubscription: Subscription;
+    taleImportCompletedSubscription: Subscription;
     taleInstanceLaunchingSubscription: Subscription;
     taleInstanceRunningSubscription: Subscription;
     taleInstanceDeletedSubscription: Subscription;
@@ -305,12 +306,23 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
         }
       });
 
-      this.subscription = this.syncService.taleUpdatedSubject.subscribe((taleId) => {
+      this.updateSubscription = this.syncService.taleUpdatedSubject.subscribe((taleId) => {
         this.logger.info("Tale update received from SyncService: ", taleId);
         if (taleId === this.taleId && !this.fetching) {
           this.fetching = true;
           setTimeout(() => {
             this.logger.info("Tale update applied via SyncService: ", taleId);
+            this.refresh();
+            this.fetching = false;
+          }, 1000);
+        }
+      });
+
+      this.taleImportCompletedSubscription = this.syncService.taleImportCompletedSubject.subscribe((taleId) => {
+        if (taleId === this.taleId && !this.fetching) {
+          this.fetching = true;
+          setTimeout(() => {
+            this.logger.info("Tale update applied after import via SyncService: ", taleId);
             this.refresh();
             this.fetching = false;
           }, 1000);
@@ -324,9 +336,10 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     }
 
     ngOnDestroy(): void {
-      this.subscription.unsubscribe();
+      this.updateSubscription.unsubscribe();
       this.removeSubscription.unsubscribe();
       this.taleUnsharedSubscription.unsubscribe();
+      this.taleImportCompletedSubscription.unsubscribe();
       this.taleInstanceLaunchingSubscription.unsubscribe();
       this.taleInstanceRunningSubscription.unsubscribe();
       this.taleInstanceDeletedSubscription.unsubscribe();

--- a/src/app/api/models/image.ts
+++ b/src/app/api/models/image.ts
@@ -48,6 +48,15 @@ export interface Image {
   public?: boolean;
 
   /**
+   * Status of the Image.
+   *   0 => INVALID
+   *   1 => UNAVAILABLE
+   *   2 => BUILDING
+   *   3 => AVAILABLE
+   */
+  status?: number;
+
+  /**
    * A human readable identification of the environment.
    */
   tags: Array<string>;

--- a/src/app/api/models/instance.ts
+++ b/src/app/api/models/instance.ts
@@ -14,6 +14,14 @@ export interface Instance {
   _id: string;
   lastActivity: string;
   name?: string;
+
+  /**
+   * Status of the Instance.
+   *   0 => LAUNCHING
+   *   1 => RUNNING
+   *   2 => ERROR
+   *   3 => DELETING
+   */
   status: number;
   taleId?: string;
   url?: string;

--- a/src/app/api/models/tale.ts
+++ b/src/app/api/models/tale.ts
@@ -115,6 +115,14 @@ export interface Tale {
   relatedIdentifiers?: Array<any>;
 
   /**
+   * Status of the Tale.
+   *   0 => PREPARING
+   *   1 => READY
+   *   2 => ERROR
+   */
+  status?: number;
+
+  /**
    * Title of the Tale
    */
   title?: string;

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.html
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.html
@@ -1,22 +1,32 @@
 <div>
-  <button *ngIf="!instance" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="startTale()">
-      <i class="play icon"></i>
-      Run Tale
-  </button>
-  <button *ngIf="instance && instance.status === 0" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="startTale()">
+  <button *ngIf="tale && tale.status === 1" class="right floated" [ngClass]="{ 'tale-button disabled': !isPrimary, 'tale-button-primary disabled': isPrimary }" disabled="true">
       <i class="fas fa-spinner fa-pulse"></i>
-      Starting...
+      Importing...
   </button>
-  <button *ngIf="instance && instance.status === 1" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="stopTale()">
-      <i class="stop icon"></i>
-      Stop Tale
-  </button>
-  <button *ngIf="instance && instance.status === 2" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="stopTale()">
+  <button *ngIf="tale && tale.status === 2" class="right floated" [ngClass]="{ 'tale-button disabled': !isPrimary, 'tale-button-primary disabled': isPrimary }" disabled="true">
       <i class="warning icon"></i>
-      Error
+      Import Failed
   </button>
-  <button *ngIf="instance && instance.status === 3" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="stopTale()">
-      <i class="fas fa-spinner fa-pulse"></i>
-      Stopping...
-  </button>
+  <div *ngIf="tale && tale.status === 2">
+      <button *ngIf="!instance" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="startTale()">
+          <i class="play icon"></i>
+          Run Tale
+      </button>
+      <button *ngIf="instance && instance.status === 0" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="startTale()">
+          <i class="fas fa-spinner fa-pulse"></i>
+          Starting...
+      </button>
+      <button *ngIf="instance && instance.status === 1" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="stopTale()">
+          <i class="stop icon"></i>
+          Stop Tale
+      </button>
+      <button *ngIf="instance && instance.status === 2" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="stopTale()">
+          <i class="warning icon"></i>
+          Error
+      </button>
+      <button *ngIf="instance && instance.status === 3" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="stopTale()">
+          <i class="fas fa-spinner fa-pulse"></i>
+          Stopping...
+      </button>
+  </div>
 </div>

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.html
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.html
@@ -1,5 +1,5 @@
 <div>
-  <button *ngIf="tale && tale.status === 1" class="right floated" [ngClass]="{ 'tale-button disabled': !isPrimary, 'tale-button-primary disabled': isPrimary }" disabled="true">
+  <button *ngIf="tale && tale.status === 0" class="right floated" [ngClass]="{ 'tale-button disabled': !isPrimary, 'tale-button-primary disabled': isPrimary }" disabled="true">
       <i class="fas fa-spinner fa-pulse"></i>
       Importing...
   </button>
@@ -7,7 +7,7 @@
       <i class="warning icon"></i>
       Import Failed
   </button>
-  <div *ngIf="tale && tale.status === 2">
+  <div *ngIf="tale && tale.status === 1">
       <button *ngIf="!instance" class="right floated" [ngClass]="{ 'tale-button': !isPrimary, 'tale-button-primary': isPrimary }" (click)="startTale()">
           <i class="play icon"></i>
           Run Tale

--- a/src/app/tales/components/tale-run-button/tale-run-button.component.scss
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.scss
@@ -4,6 +4,11 @@
   cursor: pointer;
 }
 
+.tale-button.disabled,
+.tale-button-primary.disabled {
+  cursor: not-allowed !important;
+}
+
 .tale-button:hover {
   border: solid #2185d0 1px;
   border-radius: 5px;


### PR DESCRIPTION
## Problem
Run View contains stale data after Tale import completes - needs manual refresh to pick up newly-registered datasets, related identifiers, etc

Fixes #137 
Fixes #121 

## Approach
* Wire up the Run Tale view to the SyncService to refresh Tale data when import completes for the Tale

## How to Test
1. Checkout and run this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Import a Tale (preferably a large Tale that take awhile to import and/or ultimately fails)
    * You should be brought to the Run view
    * You should see that the "Run Tale" button is disabled and reads `Importing...`
4. Wait for the Tale import to finish
    * On failure, you should see that the button stays disabled and reads `Import Failed`
    * On success, you should see the "Run Tale" button now appears as expected, allowing the user to interact with it to launch the Tale