### PR TITLE
Allow to import Tales/Binders from testing DataONE deployments

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -18,6 +18,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
   datasetCitation: any;
   asTale = false;
   gitUrl = '';
+  baseUrl = '';
 
   showGit = false;
 
@@ -44,6 +45,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       description: '### Provide a description for your Tale'
     };
     this.showGit = data.showGit;
+    this.baseUrl = (data && data.params && data.params.api) ? data.params.api : '';
   }
 
   ngOnInit(): void {
@@ -54,11 +56,11 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
     $('.ui.checkbox').checkbox();
   }
 
-  result(): { tale: Tale, asTale: boolean, url?: string } {
+  result(): { tale: Tale, asTale: boolean, url?: string, baseUrl?: string } {
     if (this.data.showGit) {
-      return { tale: this.newTale, asTale: this.asTale, url: this.gitUrl };
+      return { tale: this.newTale, asTale: this.asTale, baseUrl: this.baseUrl, url: this.gitUrl };
     } else {
-      return { tale: this.newTale, asTale: this.asTale };
+      return { tale: this.newTale, asTale: this.asTale, baseUrl: this.baseUrl };
     }
   }
 

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -53,9 +53,10 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
               width: '600px',
               data: { params: queryParams }
             });
-            dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url: string}) => {
+            dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url: string, baseUrl: string}) => {
               const tale = result.tale;
               const asTale = result.asTale;
+              const baseUrl = result.baseUrl;
 
               // Short-circuit for 'Cancel' case
               if (!tale) { return; }
@@ -68,7 +69,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
                 git: result.url ? true : false,
                 spawn: false, // if true, immediately launch a Tale instance
                 taleKwargs: tale.title ? { title: tale.title } : {}, 
-                lookupKwargs: {},
+                lookupKwargs: baseUrl ? { base_url: baseUrl } : {},
               };
               this.taleService.taleCreateTaleFromUrl(params).subscribe((response: Tale) => {
                 this.logger.debug("Successfully submitted 'Analyze in WT' Job:", response);
@@ -89,9 +90,10 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
         data: { showGit }
       };
       const dialogRef = this.dialog.open(CreateTaleModalComponent, config);
-      dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url?: string}) => {
+      dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url?: string, baseUrl: string}) => {
         const tale = result.tale;
         const gitUrl = result.url;
+        const baseUrl = result.baseUrl;
 
         if (!tale) { return; }
 
@@ -106,7 +108,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
             git: gitUrl ? true : false,
             spawn: false, // if true, immediately launch a Tale instance
             taleKwargs: tale.title ? { title: tale.title } : {},
-            lookupKwargs: {},
+            lookupKwargs: baseUrl ? { base_url: baseUrl } : {},
           };
 
           this.taleService.taleCreateTaleFromUrl(params).subscribe((response: Tale) => {


### PR DESCRIPTION
## Problem

See #193 

## Approach
Parse `api` query parameter and send it back as `lookupKwargs.base_url`

## How to Test

Explained in #193 (change `.stage` to `.local` in all urls)
