### PR TITLE
fix: change the flex direction on files table container

### DIFF
--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -34,7 +34,7 @@
 
 <input #file multiple type="file" style="display: none" (change)="onUploadsAdded($event)" />
 
-<div class="container" fxFlex fxLayout="row" fxLayoutAlign="space-between stretch">
+<div class="container" fxFlex fxLayout="column" fxLayoutAlign="space-between stretch">
   <!-- Show placeholder if there are no fileElements to display -->
   <div class="ui message" *ngIf="!fileElements || !fileElements.length">
     {{ placeholderMessage }}

--- a/src/app/files/file-explorer/file-explorer.component.scss
+++ b/src/app/files/file-explorer/file-explorer.component.scss
@@ -16,6 +16,7 @@ mat-toolbar {
 
 .ui.message {
   width: 100%;
+  height: 100%;
   max-width: none;
   border-radius: 0 0 10pt 0;
   box-shadow: none;


### PR DESCRIPTION
## Problem
Newer versions of Chrome appear to now be respecting settings that were previously ignored.

Fixes #200  ? somehow?


## Approach
* Change the `flex-direction` on the container where the files table is listed (from `row` to `column`)

NOTE: I have no idea why this suddenly broke in a new version of Chrome, or if this fix will have other weird side-effects. Keep this in mind when testing and keep note if you see any strange behavior.

## How to Test
Prerequisites: at least one Tale created, at least one file/folder in Home folder

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Files > Home for a Tale that you own
4. Upload one or more files and/or create multiple folders
    * You should see that the files / folders listed here no longer stretch to take up all available space
5. Create a new (empty) folder and navigate into it
    * You should see a message on the right stating that the folder is empty and how to fill it
    * You should see that this message still takes up all available space