### PR TITLE
fix: race condition in Run > Files, close files dropdown when clicking elsewhere

### DIFF
--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -394,6 +394,7 @@ export class TaleFilesComponent implements OnInit, OnChanges {
     this.currentRoot = undefined;
     this.currentPath = '';
     this.navigate();
+    this.ref.detectChanges();
   }
 
   isNavActive(nav: string): boolean {
@@ -446,6 +447,8 @@ export class TaleFilesComponent implements OnInit, OnChanges {
       if (pathSuffix) {
         this.currentPath = this.truncatePathSegments(pathSuffix);
       }
+
+      this.ref.detectChanges();
     });
   }
 
@@ -485,6 +488,8 @@ export class TaleFilesComponent implements OnInit, OnChanges {
       this.canNavigateUp = false;
       this.currentPath = '';
     }
+
+    this.ref.detectChanges();
   }
 
   get placeholderMessage(): string {

--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -64,10 +64,10 @@
             {{ ele.size | fileSize }}
         </td>
         <td class="center aligned">
-          <div id="more-actions-{{ ele._id }}" class="ui inline file dropdown" (click)="openMenu($event, ele)" *ngIf="showContextMenu">
+          <div id="more-actions-{{ ele._id }}" class="ui inline file dropdown more-actions" (click)="openMenu($event, ele)" *ngIf="showContextMenu">
             <!--<div class="text">More</div>-->
             <i class="dropdown icon"></i>
-            <div class="left menu" [ngStyle]="{ 'display': !showMore[ele._id] ? 'none' : 'block' }">
+            <div class="left menu">
               <div *ngIf="!readOnlyDropdown" class="item" (click)="renameElement(ele)"><i class="fas fa-edit"></i> Rename</div>
               <div *ngIf="!readOnlyDropdown" class="item" (click)="removeElement(ele)"><i class="fas fa-trash"></i> Remove</div>
               <div class="item" (click)="downloadElement(ele)"><i class="fas fa-download"></i> Download</div>

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { FileElement } from '@files/models/file-element';
 import { LogService } from '@shared/core/log.service';
@@ -63,15 +63,15 @@ const FILE_TYPES = {
   do: 'file-code',
   tsv: 'file-csv',
   tab: 'file-csv',
-  json: 'file-alt'
+  json: 'file-alt',
 };
 
 @Component({
   selector: 'app-file-explorer',
   templateUrl: './file-explorer.component.html',
-  styleUrls: ['./file-explorer.component.scss']
+  styleUrls: ['./file-explorer.component.scss'],
 })
-export class FileExplorerComponent implements OnInit {
+export class FileExplorerComponent implements OnInit, OnChanges {
   @ViewChild('file') file: any;
 
   @Input() preventNavigation = false;
@@ -115,7 +115,17 @@ export class FileExplorerComponent implements OnInit {
   constructor(private readonly dialog: MatDialog, private readonly logger: LogService) {}
 
   ngOnInit(): void {
-    $('.ui.file.dropdown').dropdown({ action: 'hide' });
+    setTimeout(() => {
+      $('.ui.file.dropdown').dropdown({ action: 'hide' });
+    }, 1000);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.currentNav) {
+      setTimeout(() => {
+        $('.ui.file.dropdown').dropdown({ action: 'hide' });
+      }, 1000);
+    }
   }
 
   getIcon(element: FileElement): string {
@@ -202,7 +212,7 @@ export class FileExplorerComponent implements OnInit {
 
   openNewFolderDialog(): void {
     const dialogRef = this.dialog.open(NewFolderDialogComponent);
-    dialogRef.afterClosed().subscribe(res => {
+    dialogRef.afterClosed().subscribe((res) => {
       if (res) {
         this.logger.debug(`Folder added: ${res}`);
         this.folderAdded.emit({ name: res });
@@ -215,7 +225,7 @@ export class FileExplorerComponent implements OnInit {
     event.stopPropagation();
 
     const dialogRef = this.dialog.open(RenameDialogComponent);
-    dialogRef.afterClosed().subscribe(res => {
+    dialogRef.afterClosed().subscribe((res) => {
       if (res) {
         this.logger.debug(`Folder renamed: ${element.name} -> ${res}`);
         element.name = res;

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { FileElement } from '@files/models/file-element';
 import { LogService } from '@shared/core/log.service';
@@ -71,7 +71,7 @@ const FILE_TYPES = {
   templateUrl: './file-explorer.component.html',
   styleUrls: ['./file-explorer.component.scss'],
 })
-export class FileExplorerComponent implements OnInit, OnChanges {
+export class FileExplorerComponent implements OnChanges {
   @ViewChild('file') file: any;
 
   @Input() preventNavigation = false;
@@ -113,12 +113,6 @@ export class FileExplorerComponent implements OnInit, OnChanges {
   showMore: any = {};
 
   constructor(private readonly dialog: MatDialog, private readonly logger: LogService) {}
-
-  ngOnInit(): void {
-    setTimeout(() => {
-      $('.ui.file.dropdown').dropdown({ action: 'hide' });
-    }, 1000);
-  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.currentNav) {


### PR DESCRIPTION
## Problem
Files dropdown menu stays open indefinitely unless toggled by clicking the button again

Fixes #10 
Also Fixes #8 

## Approach
* #8: force re-render if `currentPath` changes
* #10: Restore expected default behavior here by initializing the dropdown "correctly" to account for the async nature of the view - dropdown should now close if user clicks anywhere outside of the dropdown menu

Note: there is still a race condition in this approach if the folders/files take longer than `1000ms` to fetch then the dropdowns may not initialize properly. I am not yet sure how to remedy this problem - too long of a timeout and the user can/will notice the delay in dropdown initialization (especially when changing navs), too short and this will cause the race condition to happen more frequently.

## How to Test
Prerequisites: at least one Tale created, at least one file/folder

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Files > Home for a Tale that you own
4. Create a folder or upload a file, if you haven't already
5. Expand the dropdown next to a file or folder
    * You should see the "More Actions" dropdown appear beside the file
6. Click "Download" or "Copy" (or some an option that doesn't open a new modal)
    * Note that the menu stays open
7. Click outside of the menu, anywhere else on the page
    * You should see the dropdown now closes as expected
