### PR TITLE
Fix blank page error in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ package-lock.json
 Thumbs.db
 
 
-src/assets/env.js
+src/assets/env.json

--- a/angular.json
+++ b/angular.json
@@ -50,8 +50,8 @@
               "src/assets/data",
               "src/assets/i18n",
               "src/assets/config.local.json",
-              "src/assets/env.template.js",
-              "src/assets/env.js"
+              "src/assets/env.template.json",
+              "src/assets/env.json"
             ],
             "styles": [
               "src/assets/sass/lib.scss",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-envsubst < /usr/share/nginx/html/assets/env.template.js > /usr/share/nginx/html/assets/env.js && exec nginx -g 'daemon off;'
+envsubst < /usr/share/nginx/html/assets/env.template.json > /usr/share/nginx/html/assets/env.json && exec nginx -g 'daemon off;'

--- a/src/app/+tale-catalog/tale-catalog.module.ts
+++ b/src/app/+tale-catalog/tale-catalog.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatDialogModule } from '@angular/material/dialog';
 import { RouterModule } from '@angular/router';
 import { MaterialModule } from '@shared/material';
 import { SharedModule } from '@shared/shared.module';
@@ -22,7 +21,7 @@ import { StoppedTalesPipe } from './tale-catalog/pipes/stopped-tales.pipe';
 import { TaleCatalogComponent } from './tale-catalog/tale-catalog.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forChild(routes), MaterialModule, MatDialogModule, TalesModule, SharedModule],
+  imports: [CommonModule, RouterModule.forChild(routes), MaterialModule, TalesModule, SharedModule],
   declarations: [
     TaleCatalogComponent,
     CreateTaleModalComponent,

--- a/src/app/+tale-catalog/tale-catalog.module.ts
+++ b/src/app/+tale-catalog/tale-catalog.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { MatDialogModule } from '@angular/material/dialog';
 import { RouterModule } from '@angular/router';
 import { MaterialModule } from '@shared/material';
 import { SharedModule } from '@shared/shared.module';
@@ -21,7 +22,7 @@ import { StoppedTalesPipe } from './tale-catalog/pipes/stopped-tales.pipe';
 import { TaleCatalogComponent } from './tale-catalog/tale-catalog.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forChild(routes), MaterialModule, TalesModule, SharedModule],
+  imports: [CommonModule, RouterModule.forChild(routes), MatDialogModule, MaterialModule, TalesModule, SharedModule],
   declarations: [
     TaleCatalogComponent,
     CreateTaleModalComponent,

--- a/src/app/api/api-configuration.ts
+++ b/src/app/api/api-configuration.ts
@@ -1,14 +1,6 @@
 /* tslint:disable */
 import { Injectable } from '@angular/core';
-
-function getWindow(): any {
-  return window;
-}
-
-function getWindowApiUrl(): string {
-  let window = getWindow();
-  return window.env.apiUrl;
-}
+import { WindowService } from '@shared/core';
 
 /**
  * Global configuration for Api services
@@ -17,7 +9,11 @@ function getWindowApiUrl(): string {
   providedIn: 'root'
 })
 export class ApiConfiguration {
-  rootUrl: string = getWindowApiUrl();
+  rootUrl: string;
+
+  constructor(private window: WindowService) {
+    this.rootUrl = this.window.env.apiUrl;
+  }
 }
 
 export interface ApiConfigurationInterface {

--- a/src/app/api/token.interceptor.ts
+++ b/src/app/api/token.interceptor.ts
@@ -5,16 +5,17 @@ import { ApiConfiguration } from '@api/api-configuration';
 import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 
+// FIXME: Circular dependency here: something odd with TokenService and the HTTP_INTERCEPTORS
 import { TokenService } from './token.service';
 
 // TODO: Tests
 
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
-  constructor(public tokenService: TokenService, private readonly config: ApiConfiguration, private readonly router: Router) {}
+  constructor(/*public tokenService: TokenService,*/ private readonly config: ApiConfiguration, private readonly router: Router) {}
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     // Ignore if we don't have a token
-    const token = this.tokenService.getToken();
+    const token = localStorage.getItem('girderToken'); // this.tokenService.getToken();
     if (!token) {
       return next.handle(request).pipe(
         retry(1),

--- a/src/app/api/token.interceptor.ts
+++ b/src/app/api/token.interceptor.ts
@@ -5,17 +5,16 @@ import { ApiConfiguration } from '@api/api-configuration';
 import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 
-// FIXME: Circular dependency here: something odd with TokenService and the HTTP_INTERCEPTORS
 import { TokenService } from './token.service';
 
 // TODO: Tests
 
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
-  constructor(/*public tokenService: TokenService,*/ private readonly config: ApiConfiguration, private readonly router: Router) {}
+  constructor(public tokenService: TokenService, private readonly config: ApiConfiguration, private readonly router: Router) {}
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     // Ignore if we don't have a token
-    const token = localStorage.getItem('girderToken'); // this.tokenService.getToken();
+    const token = this.tokenService.getToken();
     if (!token) {
       return next.handle(request).pipe(
         retry(1),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,7 +34,6 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = { supp
     CoreModule.forRoot([]),
     MaterialModule,
     FontAwesomeModule,
-    ApiModule,
     NotificationStreamModule,
     ErrorHandlerModule
   ],

--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -52,7 +52,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let ele of fileElements; index as i; trackBy: trackById " (click)="navigate(ele)">
+      <tr *ngFor="let ele of fileElements; index as i; trackBy: trackById" (click)="navigate(ele)">
         <th class="center aligned"><i class="fas fa-fw fa-2x {{ getIcon(ele) }}"></i></th>
         <td [title]="ele.name">{{ ele.name | truncate:100 }}</td>
         <td [title]="ele.updated">{{ ele.updated | date }}</td>

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -115,7 +115,7 @@ export class FileExplorerComponent implements OnChanges {
   constructor(private readonly dialog: MatDialog, private readonly logger: LogService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.currentNav && changes.fileElements) {
+    if (changes.currentNav || changes.fileElements) {
       setTimeout(() => {
         $('.ui.file.dropdown').dropdown({ action: 'hide' });
       }, 1000);

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -63,13 +63,13 @@ const FILE_TYPES = {
   do: 'file-code',
   tsv: 'file-csv',
   tab: 'file-csv',
-  json: 'file-alt',
+  json: 'file-alt'
 };
 
 @Component({
   selector: 'app-file-explorer',
   templateUrl: './file-explorer.component.html',
-  styleUrls: ['./file-explorer.component.scss'],
+  styleUrls: ['./file-explorer.component.scss']
 })
 export class FileExplorerComponent implements OnChanges {
   @ViewChild('file') file: any;
@@ -115,7 +115,7 @@ export class FileExplorerComponent implements OnChanges {
   constructor(private readonly dialog: MatDialog, private readonly logger: LogService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.currentNav) {
+    if (changes.currentNav && changes.fileElements) {
       setTimeout(() => {
         $('.ui.file.dropdown').dropdown({ action: 'hide' });
       }, 1000);
@@ -134,7 +134,7 @@ export class FileExplorerComponent implements OnChanges {
 
       return `fa-${icon}`;
     } else {
-      this.logger.error('Error: unable to get icon for FileElement - unrecognized modelType:', element);
+      return `fa-spinner fa-pulse`;
     }
   }
 
@@ -206,7 +206,7 @@ export class FileExplorerComponent implements OnChanges {
 
   openNewFolderDialog(): void {
     const dialogRef = this.dialog.open(NewFolderDialogComponent);
-    dialogRef.afterClosed().subscribe((res) => {
+    dialogRef.afterClosed().subscribe(res => {
       if (res) {
         this.logger.debug(`Folder added: ${res}`);
         this.folderAdded.emit({ name: res });
@@ -219,7 +219,7 @@ export class FileExplorerComponent implements OnChanges {
     event.stopPropagation();
 
     const dialogRef = this.dialog.open(RenameDialogComponent);
-    dialogRef.afterClosed().subscribe((res) => {
+    dialogRef.afterClosed().subscribe(res => {
       if (res) {
         this.logger.debug(`Folder renamed: ${element.name} -> ${res}`);
         element.name = res;

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -48,6 +48,12 @@ export class LoginComponent extends BaseComponent implements OnInit {
       this.tokenService.setToken(token);
       this.users.userGetMe().subscribe(
         (user: any) => {
+          if (!user) {
+            this.logger.error('No user found with token.');
+
+            return;
+          }
+
           this.tokenService.user = user;
           const url = this.tokenService.getReturnRoute();
           const segments = url.split('?');
@@ -96,10 +102,10 @@ export class LoginComponent extends BaseComponent implements OnInit {
     const route = this.tokenService.getReturnRoute();
 
     // FIXME: is it ok to use window.location.origin here?
-    const params = { redirect: `${this.window.location.origin}/login?token={girderToken}&rd=${route}`, list: false };
+    const params = { redirect: `${window.location.origin}/login?token={girderToken}&rd=${route}`, list: false };
     this.oauth.oauthListProviders(params).subscribe(
       (providers: any) => {
-        this.window.location.href = providers[this.window.env.authProvider];
+        window.location.href = providers[this.window.env.authProvider];
       },
       err => {
         this.logger.error('Failed to GET /oauth/providers:', err);

--- a/src/app/shared/core/log.service.ts
+++ b/src/app/shared/core/log.service.ts
@@ -7,7 +7,7 @@ import { RemoteConsoleService } from './remote-console.service';
 
 @Injectable()
 export class LogService {
-  static readonly DEFAULT_LOG_LEVEL: LogLevel = LogLevel.Info;
+  static readonly DEFAULT_LOG_LEVEL: LogLevel = LogLevel.Error;
   readonly level: LogLevel;
 
   constructor(

--- a/src/app/shared/core/window.service.ts
+++ b/src/app/shared/core/window.service.ts
@@ -14,6 +14,8 @@ export class WindowService implements Window {
   constructor(private readonly http: HttpClient) {
     this.http.get(ENV_URL).subscribe(env => {
       this.env = env;
+    }, err => {
+      this.logger.error("Failed to fetch env: ", err);
     });
   }
 

--- a/src/app/shared/core/window.service.ts
+++ b/src/app/shared/core/window.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { LogService } from '@shared/core/log.service';
 
 import { Window } from './models/window';
 
@@ -11,12 +12,15 @@ export class WindowService implements Window {
   location: any = {};
   env: any = {};
 
-  constructor(private readonly http: HttpClient) {
-    this.http.get(ENV_URL).subscribe(env => {
-      this.env = env;
-    }, err => {
-      this.logger.error("Failed to fetch env: ", err);
-    });
+  constructor(private readonly http: HttpClient, private readonly logger: LogService) {
+    this.http.get(ENV_URL).subscribe(
+      env => {
+        this.env = env;
+      },
+      err => {
+        this.logger.error('Failed to fetch env: ', err);
+      }
+    );
   }
 
   open(url: string, target?: string): void {

--- a/src/app/shared/core/window.service.ts
+++ b/src/app/shared/core/window.service.ts
@@ -1,12 +1,21 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Window } from './models/window';
+
+const ENV_URL = '/assets/env.json';
 
 @Injectable()
 export class WindowService implements Window {
   navigator: any = {};
   location: any = {};
   env: any = {};
+
+  constructor(private readonly http: HttpClient) {
+    this.http.get(ENV_URL).subscribe(env => {
+      this.env = env;
+    });
+  }
 
   open(url: string, target?: string): void {
     return;

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule, LAYOUT_CONFIG } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
+import { ApiModule } from '@api/api.module';
 import { SafePipe } from '@shared/common/pipes/safe.pipe';
 import { TruncatePipe } from '@shared/common/pipes/truncate.pipe';
 import { MaterialModule } from '@shared/material';
@@ -17,8 +18,10 @@ export const APP_LAYOUT_CONFIG = {
   useColumnBasisZero: false
 };
 
+const DEFAULT_ROOT_URL = 'https://girder.local.wholetale.org/api/v1';
+
 @NgModule({
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ApiModule.forRoot({ rootUrl: DEFAULT_ROOT_URL })],
   providers: [
     {
       provide: LAYOUT_CONFIG,

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -1,9 +1,0 @@
-(function(window) {
-  window.env = window.env || {};
-
-  // Environment variables
-  window.env.apiUrl = '${GIRDER_API_URL}';
-  window.env.dataONEBaseUrl = '${DATAONE_URL}';
-  window.env.authProvider = '${AUTH_PROVIDER}';
-  window.env.rtdBaseUrl = '${RTD_URL}';
-})(this);

--- a/src/assets/env.template.json
+++ b/src/assets/env.template.json
@@ -1,0 +1,6 @@
+{
+  "apiUrl": "${GIRDER_API_URL}",
+  "dataONEBaseUrl": "${DATAONE_URL}",
+  "authProvider": "${AUTH_PROVIDER}",
+  "rtdBaseUrl": "${RTD_URL}"
+}

--- a/src/index.html
+++ b/src/index.html
@@ -8,8 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,600,700,800&amp;subset=latin-ext">
     <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
-    <!-- Load environment variables -->
-    <script src="assets/env.js"></script>
 </head>
 <body>
 <app-root>


### PR DESCRIPTION
## Problem
I'm not sure how this wasn't caught during my own testing, but the Docker container seems to only bring up a blank page.

This was likely a result of the Angular 9 upgrade, as lots of things moved around there.

## Approach
* Set default `LogLevel` to `Error` - previous value of `Info` was somehow hiding valuable error messages in the console
* Move `ApiModule` import from `AppModule` to `SharedModule`, fetch `env.json` from static file when initializing `WindowService` - this fixed a circular dependency
* Replace `env.js` with a static JSON file `env.json` - this seemed to behave differently when using `ng build --prod` vs `ng build`?

## How to Test
Setup:
Because the `entrypoint.sh` has changed, we need to build a new image:
1. `docker build -t yourdockeruser/ngx-dashboard:post-migration-fix .`
2. `docker push yourdockeruser/ngx-dashboard:post-migration-fix`
3. `docker service update wt_dashboard --image yourdockeruser/ngx-dashboard:post-migration-fix --force`

Test Steps:
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
    * You should be able to login and browse the platform as usual
