### PR TITLE
Instance running should update interact tab

### DIFF
--- a/src/app/tales/components/tale-run-button/tale-run-button.component.ts
+++ b/src/app/tales/components/tale-run-button/tale-run-button.component.ts
@@ -12,7 +12,7 @@ import { Subscription } from 'rxjs';
 @Component({
   selector: 'app-tale-run-button',
   templateUrl: './tale-run-button.component.html',
-  styleUrls: ['./tale-run-button.component.scss']
+  styleUrls: ['./tale-run-button.component.scss'],
 })
 export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
   @Input() instance: Instance;
@@ -26,6 +26,8 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
 
   instanceLaunchingSubscription: Subscription;
   instanceRunningSubscription: Subscription;
+  instanceDeletingSubscription: Subscription;
+  instanceDeletedSubscription: Subscription;
   instanceErrorSubscription: Subscription;
 
   constructor(
@@ -39,9 +41,21 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe(this.updateInstance);
-    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe(this.updateInstance);
-    this.instanceErrorSubscription = this.syncService.instanceErrorSubject.subscribe(this.updateInstance);
+    this.instanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe((resource) => {
+      this.updateInstance(resource);
+    });
+    this.instanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe((resource) => {
+      this.updateInstance(resource);
+    });
+    this.instanceDeletingSubscription = this.syncService.instanceDeletingSubject.subscribe((resource) => {
+      this.updateInstance(resource);
+    });
+    this.instanceDeletedSubscription = this.syncService.instanceDeletedSubject.subscribe((resource) => {
+      this.updateInstance(resource);
+    });
+    this.instanceErrorSubscription = this.syncService.instanceErrorSubject.subscribe((resource) => {
+      this.updateInstance(resource);
+    });
   }
 
   ngOnChanges(): void {
@@ -53,6 +67,8 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.instanceLaunchingSubscription.unsubscribe();
     this.instanceRunningSubscription.unsubscribe();
+    this.instanceDeletingSubscription.unsubscribe();
+    this.instanceDeletedSubscription.unsubscribe();
     this.instanceErrorSubscription.unsubscribe();
   }
 
@@ -65,6 +81,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
     this.instanceService.instanceGetInstance(resource.instanceId).subscribe((instance: Instance) => {
       this.instance = instance;
       this.ref.detectChanges();
+      this.taleInstanceStateChanged.emit(this);
     });
   }
 
@@ -101,7 +118,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
             stopPolling();
           }
         },
-        err => {
+        (err) => {
           if (err.error.message.startsWith('Invalid instance id')) {
             this.instance = undefined;
           } else {
@@ -171,7 +188,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
           this.autoRefresh();
           // });
         },
-        err => {
+        (err) => {
           this.logger.error('Failed to delete instance:', err);
           this.autoRefresh();
         }
@@ -196,7 +213,7 @@ export class TaleRunButtonComponent implements OnInit, OnChanges, OnDestroy {
           // Navigate the UI to the new Tale copy
           this.router.navigate(['run', taleCopy._id]);
         },
-        err => {
+        (err) => {
           this.logger.error('Failed to copy Tale:', err);
         }
       );

--- a/src/app/tales/sync.service.ts
+++ b/src/app/tales/sync.service.ts
@@ -3,7 +3,7 @@ import { LogService } from '@shared/core';
 import { Subject } from 'rxjs';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class SyncService {
   readonly taleCreatedSubject = new Subject<string>();
@@ -47,23 +47,23 @@ export class SyncService {
   }
 
   instanceLaunching(taleId: string, instanceId: string): void {
-    this.logger.info('Updating Instance via SyncService: ', instanceId);
+    this.logger.info('Updating Instance (Launching) via SyncService: ', instanceId);
     this.delay(() => this.instanceLaunchingSubject.next({ taleId, instanceId }));
   }
   instanceRunning(taleId: string, instanceId: string): void {
-    this.logger.info('Updating Instance via SyncService: ', instanceId);
+    this.logger.info('Updating Instance (Running) via SyncService: ', instanceId);
     this.delay(() => this.instanceRunningSubject.next({ taleId, instanceId }));
   }
   instanceDeleting(taleId: string, instanceId: string): void {
-    this.logger.info('Deleting Instance via SyncService: ', instanceId);
+    this.logger.info('Deleting Instance (Deleting) via SyncService: ', instanceId);
     this.delay(() => this.instanceDeletingSubject.next({ taleId, instanceId }));
   }
   instanceDeleted(taleId: string, instanceId: string): void {
-    this.logger.info('Deleted Instance via SyncService: ', instanceId);
+    this.logger.info('Deleted Instance (Deleted) via SyncService: ', instanceId);
     this.delay(() => this.instanceDeletedSubject.next({ taleId, instanceId }));
   }
   instanceError(taleId: string, instanceId: string): void {
-    this.logger.info('Updating Instance via SyncService: ', instanceId);
+    this.logger.info('Updating Instance (Error) via SyncService: ', instanceId);
     this.delay(() => this.instanceErrorSubject.next({ taleId, instanceId }));
   }
 


### PR DESCRIPTION
## Problem
When a Tale finishes starting up when the user is on the Interact tab, the view does not refresh automatically to show the Tale.

Instead, the view should automatically update (and not require navigation/refresh) to display the running Tale.

## Approach
The `tale-run-button` lives on the Run View (as well as on the Catalog View). This component takes care of starting / stopping Tales and previously held the logic for polling for instance status.

I think the issue here was that when an update was received from the SyncService, `emit()` was not being called to output this status change to the parent component.

Now, `tale-run-button` should call `.emit()` to `@Output` the new instance status to the `run-tale` parent component as expected.

I also improved some of the logging to print out the actual status string when updating the instance status

## How to Test
Prerequisites: at least one Tale created by you

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Start a Tale
    * You should automatically be brought to the Run > Interact view
    * You should see a loading spinner indicating that the Tale is `Launching` 
4. Wait for the Tale to finish launching
    * You should see the loading spinner disappear 
    * You should see the running Tale appear in the view 
