### PR TITLE
Render Tale Metadata when displaying "Version Info" instead of raw JSON

### DIFF
--- a/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.html
@@ -4,7 +4,7 @@
   <div class="ui grid">
     <div class="row">
       <div class="sixteen wide column" style="min-height: 300px; min-width: 300px; padding: 20px 20px 40px 0;">
-        <pre style="height:100%;">{{ data.version | json }}</pre>
+        <app-rendered-tale-metadata [tale]="data.tale" [creator]="data.tale | taleCreator | async" [collaborators]="data.collaborators"></app-rendered-tale-metadata>
       </div>
     </div>
   </div>

--- a/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.html
+++ b/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.html
@@ -4,7 +4,7 @@
   <div class="ui grid">
     <div class="row">
       <div class="sixteen wide column" style="min-height: 300px; min-width: 300px; padding: 20px 20px 40px 0;">
-        <app-rendered-tale-metadata [tale]="data.tale" [creator]="data.tale | taleCreator | async" [collaborators]="data.collaborators"></app-rendered-tale-metadata>
+        <app-rendered-tale-metadata [tale]="taleVersion" [creator]="data?.tale | taleCreator | async"></app-rendered-tale-metadata>
       </div>
     </div>
   </div>

--- a/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.ts
@@ -1,7 +1,8 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Tale, Version } from '@api/models';
 import { TaleService } from '@api/services';
+import { LogService } from '@shared/core';
 
 import { Collaborator, CollaboratorList } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
 
@@ -13,18 +14,23 @@ export class TaleVersionInfoDialogComponent implements OnInit {
   taleVersion: Tale;
 
   constructor(
+    private readonly ref: ChangeDetectorRef,
     private readonly taleService: TaleService,
+    private readonly logger: LogService,
     @Inject(MAT_DIALOG_DATA) public data: {
-                tale: Tale, version: Version, collaborators: CollaboratorList
+                tale: Tale, version: Version
               }) {}
 
   ngOnInit(): void {
+    this.logger.debug("Fetching tale version: ", this.data.version._id);
     this.fetchVersionedTaleMetadata(this.data.tale._id, this.data.version._id);
   }
 
   fetchVersionedTaleMetadata(taleId: string, versionId: string): void {
     this.taleService.taleViewRestoredVersion(taleId, versionId).subscribe(taleVersion => {
       this.taleVersion = taleVersion;
+      this.logger.debug("Fetched tale version: ", taleVersion);
+      this.ref.detectChanges();
     });
   }
 }

--- a/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.ts
+++ b/src/app/+run-tale/run-tale/modals/tale-version-info-dialog/tale-version-info-dialog.component.ts
@@ -1,13 +1,30 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Tale, Version } from '@api/models';
+import { TaleService } from '@api/services';
+
+import { Collaborator, CollaboratorList } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
 
 @Component({
   templateUrl: './tale-version-info-dialog.component.html',
   styleUrls: ['./tale-version-info-dialog.component.scss']
 })
-export class TaleVersionInfoDialogComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: {
-                tale: Tale, version: Version
+export class TaleVersionInfoDialogComponent implements OnInit {
+  taleVersion: Tale;
+
+  constructor(
+    private readonly taleService: TaleService,
+    @Inject(MAT_DIALOG_DATA) public data: {
+                tale: Tale, version: Version, collaborators: CollaboratorList
               }) {}
+
+  ngOnInit(): void {
+    this.fetchVersionedTaleMetadata(this.data.tale._id, this.data.version._id);
+  }
+
+  fetchVersionedTaleMetadata(taleId: string, versionId: string): void {
+    this.taleService.taleViewRestoredVersion(taleId, versionId).subscribe(taleVersion => {
+      this.taleVersion = taleVersion;
+    });
+  }
 }

--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -17,9 +17,9 @@
                                 <div class="ten wide column">
                                     <div class="title-info">
                                         <div class="img-holder">
-                                            <img [src]="tale.illustration" *ngIf="tale.illustration">
+                                            <img alt="illustration" [src]="tale.illustration" *ngIf="tale.illustration">
                                         </div>
-                                        <img [src]="tale.icon" class="env" *ngIf="tale.icon">
+                                        <img alt="icon" [src]="tale.icon" class="env" *ngIf="tale.icon">
                                         <div class="title">{{ tale.title | truncate:100 }}</div>
                                         <div class="author">
                                             <span *ngFor="let author of tale.authors; index as i; trackBy: trackByAuthorOrcid">
@@ -34,9 +34,9 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="six wide column" style="text-align: right">
+                                <div class="six wide column" style="text-align: right;">
                                     <app-tale-run-button class="tale-run-button" [tale]="tale" [instance]="instance" isPrimary="true" (taleInstanceStateChanged)="taleInstanceStateChanged($event)"></app-tale-run-button>
-                                    <a [routerLink]="dashboardLink" routerLinkActive="active" class="ui button" style="margin-right: 10px">
+                                    <a [routerLink]="dashboardLink" routerLinkActive="active" class="ui button" style="margin-right: 10px;">
                                         Close
                                     </a>
 
@@ -71,7 +71,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="ui secondary pointing menu" style="margin-top: 0">
+                    <div class="ui secondary pointing menu" style="margin-top: 0;">
                         <a class="item" [ngClass]="{ 'active': isTabActive('interact') }" (click)="switchTab('interact')">
                           Interact
                         </a>
@@ -122,7 +122,7 @@
                                     </div>
                                 </div>
                                 <div class="four wide right floated column" *ngIf="isVersionsPanelShown()">
-                                    <app-tale-versions-panel [tale]="tale" (taleVersionChanged)="taleVersionChanged($event)"></app-tale-versions-panel>
+                                    <app-tale-versions-panel [tale]="tale" [collaborators]="collaborators" (taleVersionChanged)="taleVersionChanged($event)"></app-tale-versions-panel>
                                 </div>
                             </div>
                         </div>

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -7,6 +7,7 @@ import { InstanceService, TaleService, UserService, VersionService } from '@api/
 import { TokenService } from '@api/token.service';
 import { AlertModalComponent } from '@shared/common/components/alert-modal/alert-modal.component';
 import { BaseComponent, LogService, WindowService } from '@shared/core';
+import { CollaboratorList } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { SyncService } from '@tales/sync.service';
 import { Subscription } from 'rxjs';
@@ -39,7 +40,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     showVersionsPanel = false;
     fetching = false;
 
-    collaborators: { users: Array<User>, groups: Array<User> } = { users: [], groups: [] };
+    collaborators: CollaboratorList = { users: [], groups: [] };
 
     removeSubscription:Subscription;
     updateSubscription: Subscription;

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -187,97 +187,9 @@ Fields Names / Order:
       </form>
 
       <!-- View Mode (read-only) -->
-      <div id="readOnlyMetadata" class="ui grid" *ngIf="!editing">
+      <div id="readOnlyMetadata" class="ui grid">
         <div class="ten wide column">
-          <div class="ui list">
-            <div class="item">
-              <b>Title:</b>
-              <span>{{ tale.title }}</span>
-            </div>
-
-            <div class="item" *ngIf="creator">
-              <b>Created By:</b>
-              <span>{{ creator.firstName }} {{ creator.lastName }}</span>
-            </div>
-
-            <div class="item">
-              <b>Authors:</b>
-              <span *ngFor="let author of tale.authors; index as i; trackBy: trackById">
-                  <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>
-              </span>
-              <span *ngIf="!tale.authors.length && creator">{{ creator.firstName }} {{ creator.lastName }}</span>
-              <span *ngIf="!tale.authors.length && !creator">???</span>
-            </div>
-
-            <div class="item">
-              <b>Category:</b>
-              <span class="category">{{ tale.category }}</span>
-            </div>
-
-            <div class="item">
-              <b>Environment:</b>
-              <img *ngIf="tale.icon" class="ui image" [src]="tale.icon | safe:'url'" style="height:1.5em; margin:0 .4em; display: inline-block">
-              <span *ngIf="(tale | taleImage | async) as environment">{{ environment.name }}</span>
-            </div>
-
-            <div class="item">
-              <b>License:</b>
-              <span>{{ tale.licenseSPDX }}</span>
-            </div>
-
-            <div class="item">
-              <b>Description:</b>
-              <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
-            </div>
-
-<!--
-            <div class="item">
-                <b>Involatile Data:</b>
-                <span *ngIf="!tale.dataSet.length">No citable data</span>
-                <ul *ngIf="tale.dataSet.length">
-                <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
-                    <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
-                </li>
-                </ul>
-            </div>
--->
-            <div class="item">
-              <b>Datasets Used:</b>
-              <span *ngIf="!tale.dataSetCitation.length">No citable data</span>
-              <ul *ngIf="tale.dataSetCitation.length" style="max-width:60vw">
-                <li *ngFor="let citation of tale.dataSetCitation">
-                    <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files', nav: 'external_data' }" routerLinkActive="active" queryParamsHandling="merge">
-                        {{ citation }}
-                    </a>
-                </li>
-              </ul>
-            </div>
-
-            <div class="item" *ngIf="tale.relatedIdentifiers && tale.relatedIdentifiers.length">
-                <b>Related Identifiers:</b>
-                <ul>
-                <li *ngFor="let ident of tale.relatedIdentifiers; index as i; trackBy: trackById">
-                    {{ ident.relation }} <a [href]="transformIdentifier(ident.identifier)" target="_blank">{{ ident.identifier }}</a>
-                </li>
-                </ul>
-            </div>
-
-            <div class="item">
-              <b>Published Location:</b>
-              <span *ngIf="latestPublish"><a [href]="latestPublish.uri">{{ latestPublish.pid }}</a></span>
-              <span *ngIf="!latestPublish">This Tale has not been published</span>
-            </div>
-
-
-            <div class="item">
-                <b>Date Created:</b>
-                <span>{{ tale.created | date }}</span>
-            </div>
-            <div class="item">
-                <b>Last Updated:</b>
-                <span>{{ tale.updated | date }}</span>
-            </div>
-          </div>
+          <app-rendered-tale-metadata *ngIf="!editing" [tale]="tale" [creator]="creator" [collaborators]="collaborators"></app-rendered-tale-metadata>
 
           <div class="inline fields ui grid" *ngIf="canEdit">
             <label class="two wide column right aligned"></label>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -11,27 +11,10 @@ import { TaleAuthor } from '@tales/models/tale-author';
 import { SyncService } from '@tales/sync.service';
 import { Observable } from 'rxjs';
 
+import { Collaborator, CollaboratorList } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
 
 // import * as $ from 'jquery';
 declare var $: any;
-
-// FIXME: Duplicated code - see tale-sharing.component.ts
-interface CollaboratorList {
-  users: Array<Collaborator>;
-  groups: Array<Collaborator>;
-}
-
-// FIXME: Duplicated code - see tale-sharing.component.ts
-interface Collaborator {
-  id: string;
-  level: number;
-  login: string;
-  name: string;
-  flags?: Array<any>;
-  showAlert?: boolean;
-  gravatar_baseUrl?: string;
-  affiliation?: string;
-}
 
 interface TaleAuthorValidationError {
   index: number;

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -42,7 +42,6 @@
               <div class="menu left transition hidden" tabindex="-1" style="display: block !important;">
                 <div class="item" (click)="viewVersionInfo(version)">View Info</div>
 
-                <!-- TODO: Restore Version button -->
                 <div class="item" (click)="restoreVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Restore</div>
 
                 <!-- TODO: Compare Versions button -->

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -6,6 +6,7 @@ import { TaleService, VersionService } from '@api/services';
 import { TokenService } from '@api/token.service';
 import { LogService, WindowService } from '@shared/core';
 import { NotificationService } from '@shared/error-handler/services/notification.service';
+import { CollaboratorList } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
 import { SyncService } from '@tales/sync.service';
 import { Subscription } from 'rxjs';
 
@@ -26,6 +27,7 @@ interface VersionUpdate {
 })
 export class TaleVersionsPanelComponent implements OnInit, OnChanges {
   @Input() tale: Tale;
+  @Input() collaborators: CollaboratorList
 
   @Output() readonly taleVersionChanged = new EventEmitter<VersionUpdate>();
 
@@ -142,7 +144,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges {
   /** Per-version dropdown options */
   viewVersionInfo(version: Version): void {
     this.dialog.open(TaleVersionInfoDialogComponent, {
-      data: { version, tale: this.tale }
+      data: { version, tale: this.tale, collaborators: this.collaborators }
     });
   }
 

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -34,7 +34,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       title: (data && data.params) ? data.params.name : '',
       imageId: '',
       authors: [],
-      license: 'CC-BY-4.0',
+      licenseSPDX: 'CC-BY-4.0',
       category: 'science',
       publishInfo: [],
       dataSet: [],

--- a/src/app/api/models/tale.ts
+++ b/src/app/api/models/tale.ts
@@ -50,7 +50,8 @@ export interface Tale {
    * A unique identifier of the user that created the tale.
    */
   creatorId?: string;
-  dataSet: DataSet;
+  dataSet?: DataSet;
+  dataSetCitation?: Array<string>;
 
   /**
    * The description of the Tale (Markdown)
@@ -78,7 +79,7 @@ export interface Tale {
   authors: Array<TaleAuthor>;
 
   /**
-   * A URL to an image depicturing the content of the Tale
+   * A URL to an image depicting the content of the Tale
    */
   illustration?: string;
 
@@ -91,7 +92,7 @@ export interface Tale {
   /**
    * The license that the Tale is under
    */
-  license: string;
+  licenseSPDX?: string;
 
   /**
    * List of Girder Items containing Tale's narrative

--- a/src/app/api/services/tale.service.ts
+++ b/src/app/api/services/tale.service.ts
@@ -9,7 +9,7 @@ import { map as __map, filter as __filter } from 'rxjs/operators';
 
 import { Tale } from '../models/tale';
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 class TaleService extends __BaseService {
   static readonly taleListTalesPath = '/tale';
@@ -66,12 +66,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('GET', this.rootUrl + `/tale`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -96,7 +96,7 @@ class TaleService extends __BaseService {
    * - `imageId`: The ID of the tale's image.
    */
   taleListTales(params: TaleService.TaleListTalesParams): __Observable<null> {
-    return this.taleListTalesResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleListTalesResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -110,12 +110,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('POST', this.rootUrl + `/tale`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -124,7 +124,7 @@ class TaleService extends __BaseService {
    * @param tale A new tale
    */
   taleCreateTale(tale: Tale): __Observable<null> {
-    return this.taleCreateTaleResponse(tale).pipe(__map(_r => _r.body as null));
+    return this.taleCreateTaleResponse(tale).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -159,12 +159,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('POST', this.rootUrl + `/tale/import`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -188,7 +188,7 @@ class TaleService extends __BaseService {
    * - `asTale`: If True, assume that external dataset is a Tale.
    */
   taleCreateTaleFromUrl(params: TaleService.TaleCreateTaleFromUrlParams): __Observable<null> {
-    return this.taleCreateTaleFromUrlResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleCreateTaleFromUrlResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -207,12 +207,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('DELETE', this.rootUrl + `/tale/${params.id}`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -225,7 +225,7 @@ class TaleService extends __BaseService {
    * - `progress`: Whether to record progress on this task.
    */
   taleDeleteTale(params: TaleService.TaleDeleteTaleParams): __Observable<null> {
-    return this.taleDeleteTaleResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleDeleteTaleResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -239,12 +239,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('GET', this.rootUrl + `/tale/${id}`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -253,7 +253,7 @@ class TaleService extends __BaseService {
    * @param id The ID of the document.
    */
   taleGetTale(id: string): __Observable<null> {
-    return this.taleGetTaleResponse(id).pipe(__map(_r => _r.body as null));
+    return this.taleGetTaleResponse(id).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -272,12 +272,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('PUT', this.rootUrl + `/tale/${params.id}`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -290,7 +290,7 @@ class TaleService extends __BaseService {
    * - `id`: The ID of the document.
    */
   taleUpdateTale(params: TaleService.TaleUpdateTaleParams): __Observable<null> {
-    return this.taleUpdateTaleResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleUpdateTaleResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -304,12 +304,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('GET', this.rootUrl + `/tale/${id}/access`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -318,7 +318,7 @@ class TaleService extends __BaseService {
    * @param id The ID of the document.
    */
   taleGetTaleAccess(id: string): __Observable<null> {
-    return this.taleGetTaleAccessResponse(id).pipe(__map(_r => _r.body as null));
+    return this.taleGetTaleAccessResponse(id).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -343,12 +343,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('PUT', this.rootUrl + `/tale/${params.id}/access`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -365,7 +365,7 @@ class TaleService extends __BaseService {
    * - `public`: Whether the tale should be publicly visible.
    */
   taleUpdateTaleAccess(params: TaleService.TaleUpdateTaleAccessParams): __Observable<null> {
-    return this.taleUpdateTaleAccessResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleUpdateTaleAccessResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -384,12 +384,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('PUT', this.rootUrl + `/tale/${params.id}/build`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -402,7 +402,7 @@ class TaleService extends __BaseService {
    * - `force`: If true, force build regardless of workspace changes
    */
   taleBuildImage(params: TaleService.TaleBuildImageParams): __Observable<null> {
-    return this.taleBuildImageResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleBuildImageResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -416,12 +416,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('POST', this.rootUrl + `/tale/${id}/copy`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -430,7 +430,7 @@ class TaleService extends __BaseService {
    * @param id The ID of the document.
    */
   taleCopyTale(id: string): __Observable<null> {
-    return this.taleCopyTaleResponse(id).pipe(__map(_r => _r.body as null));
+    return this.taleCopyTaleResponse(id).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -449,12 +449,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('GET', this.rootUrl + `/tale/${params.id}/export`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -467,7 +467,7 @@ class TaleService extends __BaseService {
    * - `taleFormat`: Format of the exported Tale
    */
   taleExportTale(params: TaleService.TaleExportTaleParams): __Observable<null> {
-    return this.taleExportTaleResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleExportTaleResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -486,12 +486,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('GET', this.rootUrl + `/tale/${params.id}/manifest`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -504,7 +504,7 @@ class TaleService extends __BaseService {
    * - `expandFolders`: If True, folders in Tale's dataSet are recursively expanded to items in the 'aggregates' section
    */
   taleGenerateManifest(params: TaleService.TaleGenerateManifestParams): __Observable<null> {
-    return this.taleGenerateManifestResponse(params).pipe(__map(_r => _r.body as null));
+    return this.taleGenerateManifestResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -524,12 +524,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('PUT', this.rootUrl + `/tale/${params.id}/publish`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -543,7 +543,7 @@ class TaleService extends __BaseService {
    * - `repository`: The repository URL of the publish destination.
    */
   talePublishTale(params: TaleService.TalePublishTaleParams): __Observable<null> {
-    return this.talePublishTaleResponse(params).pipe(__map(_r => _r.body as null));
+    return this.talePublishTaleResponse(params).pipe(__map((_r) => _r.body as null));
   }
 
   /**
@@ -560,12 +560,12 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('PUT', this.rootUrl + `/tale/${id}/git`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
@@ -577,7 +577,7 @@ class TaleService extends __BaseService {
    * - `url`: The URL of the Git repo to import.
    */
   taleUpdateGit(id: string, url: string): __Observable<null> {
-    return this.taleUpdateGitResponse(id, url).pipe(__map(_r => _r.body as null));
+    return this.taleUpdateGitResponse(id, url).pipe(__map((_r) => _r.body as null));
   }
 
   taleRestoreVersionResponse(id: string, versionId: string): __Observable<__StrictHttpResponse<null>> {
@@ -588,19 +588,40 @@ class TaleService extends __BaseService {
     let req = new HttpRequest<any>('PUT', this.rootUrl + `/tale/${id}/restore`, __body, {
       headers: __headers,
       params: __params,
-      responseType: 'json'
+      responseType: 'json',
     });
 
     return this.http.request<any>(req).pipe(
-      __filter(_r => _r instanceof HttpResponse),
-      __map(_r => {
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
         return _r as __StrictHttpResponse<null>;
       })
     );
   }
 
   taleRestoreVersion(id: string, versionId: string): __Observable<null> {
-    return this.taleRestoreVersionResponse(id, versionId).pipe(__map(_r => _r.body as null));
+    return this.taleRestoreVersionResponse(id, versionId).pipe(__map((_r) => _r.body as null));
+  }
+  taleViewRestoredVersionResponse(id: string, versionId: string): __Observable<__StrictHttpResponse<null>> {
+    let __params = this.newParams();
+    let __headers = new HttpHeaders();
+    if (versionId != null) __params = __params.set('versionId', versionId.toString());
+    let req = new HttpRequest<any>('GET', this.rootUrl + `/tale/${id}/restore`, {
+      headers: __headers,
+      params: __params,
+      responseType: 'json',
+    });
+
+    return this.http.request<any>(req).pipe(
+      __filter((_r) => _r instanceof HttpResponse),
+      __map((_r) => {
+        return _r as __StrictHttpResponse<null>;
+      })
+    );
+  }
+
+  taleViewRestoredVersion(id: string, versionId: string): __Observable<null> {
+    return this.taleViewRestoredVersionResponse(id, versionId).pipe(__map((_r) => _r.body as null));
   }
 }
 

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.e2e-spec.ts
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.e2e-spec.ts
@@ -1,0 +1,14 @@
+import { baseUrl, browser } from 'e2e-config';
+import { e2e } from '~/app/framework/testing/e2e';
+
+e2e.describe('TaleRunButtonComponent', () => {
+  e2e.it('should redirect to login page', async () => {
+    const page = browser.goto(`${baseUrl}/secure-page`);
+
+    const text = await page.evaluate(() => document.title).end();
+
+    // NOTE: title may change from login page to secure page
+    // depending on auth status
+    e2e.e(text).toContain('ng-seed/universal');
+  });
+});

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.e2e-spec.ts
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { baseUrl, browser } from 'e2e-config';
 import { e2e } from '~/app/framework/testing/e2e';
 
-e2e.describe('TaleRunButtonComponent', () => {
+e2e.describe('RenderedTaleMetadataComponent', () => {
   e2e.it('should redirect to login page', async () => {
     const page = browser.goto(`${baseUrl}/secure-page`);
 

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.html
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.html
@@ -1,5 +1,5 @@
 
-<div class="ui list">
+<div class="ui list" *ngIf="tale">
   <div class="item">
     <b>Title:</b>
     <span>{{ tale.title }}</span>
@@ -10,7 +10,7 @@
     <span>{{ creator.firstName }} {{ creator.lastName }}</span>
   </div>
 
-  <div class="item">
+  <div class="item" *ngIf="tale?.authors?.length">
     <b>Authors:</b>
     <span *ngFor="let author of tale.authors; index as i; trackBy: trackById">
               <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.html
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.html
@@ -1,0 +1,90 @@
+
+<div class="ui list">
+  <div class="item">
+    <b>Title:</b>
+    <span>{{ tale.title }}</span>
+  </div>
+
+  <div class="item" *ngIf="creator">
+    <b>Created By:</b>
+    <span>{{ creator.firstName }} {{ creator.lastName }}</span>
+  </div>
+
+  <div class="item">
+    <b>Authors:</b>
+    <span *ngFor="let author of tale.authors; index as i; trackBy: trackById">
+              <span *ngIf="i > 0">, </span> <span [title]="author.orcid">{{ author.firstName }} {{ author.lastName }}</span>
+          </span>
+    <span *ngIf="!tale.authors.length && creator">{{ creator.firstName }} {{ creator.lastName }}</span>
+    <span *ngIf="!tale.authors.length && !creator">???</span>
+  </div>
+
+  <div class="item">
+    <b>Category:</b>
+    <span class="category">{{ tale.category }}</span>
+  </div>
+
+  <div class="item">
+    <b>Environment:</b>
+    <img *ngIf="tale.icon" class="ui image" [src]="tale.icon | safe:'url'" style="height:1.5em; margin:0 .4em; display: inline-block">
+    <span *ngIf="(tale | taleImage | async) as environment">{{ environment.name }}</span>
+  </div>
+
+  <div class="item">
+    <b>License:</b>
+    <span>{{ tale.licenseSPDX }}</span>
+  </div>
+
+  <div class="item">
+    <b>Description:</b>
+    <markdown ngPreserveWhitespaces [data]="tale.description"></markdown>
+  </div>
+
+  <!--
+              <div class="item">
+                  <b>Involatile Data:</b>
+                  <span *ngIf="!tale.dataSet.length">No citable data</span>
+                  <ul *ngIf="tale.dataSet.length">
+                  <li *ngFor="let dataset of tale.dataSet; index as i; trackBy: trackById">
+                      <a [href]="apiRoot + (dataset._modelType === 'folder' ? '/folder/' : '/item/') + dataset.itemId + '/download?contentDisposition=attachment'" target="_blank">{{ dataset.mountPath }}</a>
+                  </li>
+                  </ul>
+              </div>
+  -->
+  <div class="item">
+    <b>Datasets Used:</b>
+    <span *ngIf="!tale.dataSetCitation.length">No citable data</span>
+    <ul *ngIf="tale.dataSetCitation.length" style="max-width:60vw">
+      <li *ngFor="let citation of tale.dataSetCitation">
+        <a routerLink="/run/{{ tale._id }}" [queryParams]="{ tab: 'files', nav: 'external_data' }" routerLinkActive="active" queryParamsHandling="merge">
+          {{ citation }}
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="item" *ngIf="tale.relatedIdentifiers && tale.relatedIdentifiers.length">
+    <b>Related Identifiers:</b>
+    <ul>
+      <li *ngFor="let ident of tale.relatedIdentifiers; index as i; trackBy: trackById">
+        {{ ident.relation }} <a [href]="transformIdentifier(ident.identifier)" target="_blank">{{ ident.identifier }}</a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="item">
+    <b>Published Location:</b>
+    <span *ngIf="latestPublish"><a [href]="latestPublish.uri">{{ latestPublish.pid }}</a></span>
+    <span *ngIf="!latestPublish">This Tale has not been published</span>
+  </div>
+
+
+  <div class="item">
+    <b>Date Created:</b>
+    <span>{{ tale.created | date }}</span>
+  </div>
+  <div class="item">
+    <b>Last Updated:</b>
+    <span>{{ tale.updated | date }}</span>
+  </div>
+</div>

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.scss
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.scss
@@ -1,0 +1,28 @@
+.tale-button {
+  padding: 10px;
+  color: #2185d0;
+  cursor: pointer;
+}
+
+.tale-button.disabled,
+.tale-button-primary.disabled {
+  cursor: not-allowed !important;
+}
+
+.tale-button:hover {
+  border: solid #2185d0 1px;
+  border-radius: 5px;
+}
+
+.tale-button-primary {
+  padding: 12px 24px 12px 24px;
+  border-radius: 5px;
+  background-color: #2185d0;
+  color: #eeeeee;
+  cursor: pointer;
+}
+
+.fas.fa-spinner.fa-pulse {
+  margin: 0 5px 0 0;
+  padding: 0;
+}

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.spec.ts
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RenderedTaleMetadataComponent } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
+
+import { TaleRunButtonComponent } from './tale-run-button.component';
+
+describe('RenderedTaleMetadataComponent', () => {
+  let component: RenderedTaleMetadataComponent;
+  let fixture: ComponentFixture<RenderedTaleMetadataComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [RenderedTaleMetadataComponent],
+      }).compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RenderedTaleMetadataComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.ts
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.ts
@@ -33,7 +33,6 @@ export interface Collaborator {
 export class RenderedTaleMetadataComponent {
   @Input() tale: Tale;
   @Input() creator: User;
-  @Input() collaborators: CollaboratorList;
 
   // FIXME: Duplicated code (see publish-tale-dialog.component.ts)
   get latestPublish(): PublishInfo {

--- a/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.ts
+++ b/src/app/tales/components/rendered-tale-metadata/rendered-tale-metadata.component.ts
@@ -1,0 +1,78 @@
+import { Component, Input } from '@angular/core';
+import { PublishInfo } from '@api/models/publish-info';
+import { Tale } from '@api/models/tale';
+import { User } from '@api/models/user';
+import { TaleAuthor } from '@tales/models/tale-author';
+
+// import * as $ from 'jquery';
+declare var $: any;
+
+// FIXME: Duplicated code - see tale-sharing.component.ts
+export interface CollaboratorList {
+  users: Array<Collaborator>;
+  groups: Array<Collaborator>;
+}
+
+// FIXME: Duplicated code - see tale-sharing.component.ts
+export interface Collaborator {
+  id: string;
+  level: number;
+  login: string;
+  name: string;
+  flags?: Array<any>;
+  showAlert?: boolean;
+  gravatar_baseUrl?: string;
+  affiliation?: string;
+}
+
+@Component({
+  selector: 'app-rendered-tale-metadata',
+  templateUrl: './rendered-tale-metadata.component.html',
+  styleUrls: ['./rendered-tale-metadata.component.scss'],
+})
+export class RenderedTaleMetadataComponent {
+  @Input() tale: Tale;
+  @Input() creator: User;
+  @Input() collaborators: CollaboratorList;
+
+  // FIXME: Duplicated code (see publish-tale-dialog.component.ts)
+  get latestPublish(): PublishInfo {
+    if (!this.tale?.publishInfo?.length) {
+      return undefined;
+    }
+
+    // Sort by date, then
+    return this.tale.publishInfo
+      .sort((a: PublishInfo, b: PublishInfo) => {
+        // Example Format: "2019-01-23T15:48:17.476000+00:0"
+        const dateA = Date.parse(a.date);
+        const dateB = Date.parse(b.date);
+        if (dateA > dateB) {
+          return 1;
+        }
+        if (dateA < dateB) {
+          return -1;
+        }
+
+        return 0;
+      })
+      .slice(-1)
+      .pop();
+  }
+
+  trackById(index: number, model: any): string {
+    return model._id || model.orcid || model.itemId || model.identifier;
+  }
+
+  trackByAuthorHash(index: number, author: TaleAuthor): number {
+    return index;
+  }
+
+  transformIdentifier(identifier: string): string {
+    if (identifier.indexOf('doi:') === 0) {
+      return identifier.replace('doi:', 'https://doi.org/');
+    }
+
+    return identifier;
+  }
+}

--- a/src/app/tales/tales.module.ts
+++ b/src/app/tales/tales.module.ts
@@ -2,18 +2,34 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MaterialModule } from '@shared/material';
+import { MarkdownModule } from 'ngx-markdown';
 import { SharedModule } from '~/app/shared';
 
 import { CopyOnLaunchModalComponent } from './components/modals/copy-on-launch-modal/copy-on-launch-modal.component';
+import { RenderedTaleMetadataComponent } from './components/rendered-tale-metadata/rendered-tale-metadata.component';
 import { TaleRunButtonComponent } from './components/tale-run-button/tale-run-button.component';
 import { TaleCreatorPipe } from './pipes/tale-creator.pipe';
 import { TaleImagePipe } from './pipes/tale-image.pipe';
 import { TaleNamePipe } from './pipes/tale-name.pipe';
 
 @NgModule({
-  declarations: [CopyOnLaunchModalComponent, TaleRunButtonComponent, TaleCreatorPipe, TaleImagePipe, TaleNamePipe],
-  exports: [TaleRunButtonComponent, CopyOnLaunchModalComponent, TaleCreatorPipe, TaleImagePipe, TaleNamePipe],
+  declarations: [
+    CopyOnLaunchModalComponent,
+    TaleRunButtonComponent,
+    RenderedTaleMetadataComponent,
+    TaleCreatorPipe,
+    TaleImagePipe,
+    TaleNamePipe,
+  ],
+  exports: [
+    TaleRunButtonComponent,
+    RenderedTaleMetadataComponent,
+    CopyOnLaunchModalComponent,
+    TaleCreatorPipe,
+    TaleImagePipe,
+    TaleNamePipe,
+  ],
   providers: [TaleNamePipe],
-  imports: [CommonModule, MaterialModule, MatDialogModule, SharedModule]
+  imports: [CommonModule, MaterialModule, MatDialogModule, SharedModule, MarkdownModule],
 })
 export class TalesModule {}


### PR DESCRIPTION
## Problem
Viewing a Tale "Version Info" only shows raw JSON.

Fixes #144 

## Approach
Show rendered Tale metadata from the selected version instead of raw JSON.

* Add new API call to `TaleService` for `GET /tale/{id}/restore`
* Refactor `tale-metadata-tab` to isolate the readonly part into a new component called `rendered-tale-metadata`
* Replace content of TaleVersionInfoDialogComponent to display the new `rendered-tale-metadata` component

## How to Test
Prerequisites: at least on Tale created that you own

1. Checkout this branch locally (along with https://github.com/whole-tale/wt_versioning/pull/24), rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Run View for a Tale that you own
4. Create a version of the Tale (if you haven't already)
5. Expand the dropdown beside the new version and choose "View Version Info"
    * You should see the TaleVersionInfoDialogComponent appear
    * You should see a rendered copy of the Tale version's metadata is shown
    * You should see that all fields appear in the same order as in the Run Tale > Metadata view
6. Add an author to the Tale and save a new version
7. "View Version Info" for the new version you created, compare with old "Version Info" contents
    * You should see that the author you added appears here, but does not appear in the previous "Version Info"