### PR TITLE
Own acl

### DIFF
--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.html
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.html
@@ -54,6 +54,7 @@
               <div class="menu">
                 <div class="item" data-value="0">Can View</div>
                 <div class="item" data-value="1">Can Edit</div>
+                <div class="item" data-value="2">Owns</div>
               </div>
            </div>
            <button class="ui button primary" [disabled]="!newCollabUser" (click)="addCollaborator()">Add</button>
@@ -76,6 +77,7 @@
                        <div class="menu">
                          <div class="item access-dropdown" data-value="0">Can View</div>
                          <div class="item access-dropdown" data-value="1">Can Edit</div>
+                         <div class="item access-dropdown" data-value="2">Owns</div>
                        </div>
                     </div>
 

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
@@ -241,9 +241,20 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
   }
 
   addCollaborator(): void {
+    var newAccessLevel = AccessLevel.None;
+    if (this.newCollabAccess === 0) {
+      newAccessLevel = AccessLevel.Read;
+    } else if (this.newCollabAccess === 1) {
+      newAccessLevel = AccessLevel.Write;
+    } else if (this.newCollabAccess === 2) {
+      newAccessLevel = AccessLevel.Admin;
+    } else {
+      this.logger.error(`Unknown Access Level: ${this.newCollabAccess}`);
+    }
+
     const collab: Collaborator = {
       id: this.newCollabUser._id,
-      level: this.newCollabAccess === 1 ? AccessLevel.Write : AccessLevel.Read,
+      level: newAccessLevel,
       login: this.newCollabUser.login,
       name: this.newCollabUser.name,
       showAlert: true,

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -48,7 +48,7 @@
                 <div class="item" *ngIf="false">Compare</div>
 
                 <div class="item" (click)="renameVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Rename</div>
-                <div class="item" (click)="deleteVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Delete</div>
+                <div class="item" (click)="deleteVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Admin">Delete</div>
                 <div class="item" (click)="exportVersion(version)" *ngIf="tale._accessLevel >= AccessLevel.Write">Export</div>
               </div>
           </div>


### PR DESCRIPTION
## Problem

ADMIN / Own ACL is missing. See #230 

## Approach

Adds a missing ACL that's supported by the backend, where it's necessary

## How to Test

1. Checkout this branch locally, rebuild the dashboard
1. Create additional users (`scripts/create_extra_users.py`)
1. Login to the WholeTale Dashboard
1. Create a Tale. Navigate to Tale > Share
2. Go wild with new "Owns" ACL
3. Inspect the Tale object to confirm user has access level "2"
