### PR TITLE
Various bugfixes: dropdown behavior, export version, missing icon, add user, apiUrl config, update caniuse

### DIFF
--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -46,6 +46,8 @@ export class TaleMetadataComponent implements OnInit {
   get canEdit(): boolean {
     if (!this.tale) {
       return false;
+    } else if (this.editing) {
+      return false;
     }
 
     return this.tale._accessLevel >= AccessLevel.Write;

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.html
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.html
@@ -39,7 +39,7 @@
          <p>Invite new collaborator:</p>
 
          <div class="ui action input">
-            <div class="ui category search" id="userSearch">
+            <div class="ui search" id="userSearch">
               <div class="ui left icon input">
                 <i class="search icon"></i>
                 <input id="userSearchInput" class="prompt" type="text" name="search" placeholder="Search users...">

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
@@ -159,9 +159,16 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
         'lastName',
         'description',
       ],
-      onSelect: (result: any, response: any): boolean => {
-        this.logger.debug('Selected:', result);
+      onSelect: (multi: boolean, selections: Array<any>): boolean => {
+        this.logger.debug('Selected:', selections);
 
+        if (selections.length === 0) {
+          this.logger.warn('Warning: No selected user');
+        } else if (selections.length > 1) {
+          this.logger.warn('Warning: Multiple selected users');
+        }
+
+        const result = selections.shift()
         const displayName = result.login;
         $('#userSearch').search('set value', displayName);
         // $('#userSearch').find('input').val(displayName);

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
@@ -119,25 +119,28 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
     // Initialize the user search
     $('#userSearch').search({
       source: filteredUsers,
-      type: 'standard',
-      fullTextSearch: 'true',
+      fullTextSearch: true,
       searchOnFocus: true,
       debug: false,
       verbose: false,
       minCharacters: 0,
+      type: 'standard',
       templates: {
         // Customize user search result template
         standard: (response: any, fields: any) => {
-          // this.users = response.results;
           // returns results html for custom results
           let template = `<div class="ui relaxed divided list" style="padding:10px;">`
           response.results.forEach((result: User) => template += `
             <a class="item clickable result">
-              <img class="ui avatar circular image" src="${result[fields.image] || this.defaultImageUrl}"
-                  style="float:left;height:2em;width:2em;margin-right:10px;" />
-              <div class="content">
-                <div class="title">${result[fields.title]}</div>
-                <div class="description">${result[fields.description]}</div>
+              <div class="row">
+                <div class="six wide column">
+                  <img class="ui avatar circular image" src="${result[fields.image] || this.defaultImageUrl}"
+                      style="float:left;height:2em;width:2em;margin-right:10px;" />
+                </div>
+                <div class="ten wide column">
+                  <div class="title">${result[fields.title]}</div>
+                  <div class="description">${result[fields.description]}</div>
+                </div>
               </div>
             </a>`)
           template += `</div>`
@@ -159,30 +162,27 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
         'lastName',
         'description',
       ],
-      onSelect: (multi: boolean, selections: Array<any>): boolean => {
-        this.logger.debug('Selected:', selections);
-
-        if (selections.length === 0) {
-          this.logger.warn('Warning: No selected user');
-        } else if (selections.length > 1) {
-          this.logger.warn('Warning: Multiple selected users');
-        }
-
-        const result = selections.shift()
-        const displayName = result.login;
-        $('#userSearch').search('set value', displayName);
-        // $('#userSearch').find('input').val(displayName);
+      onSelect: (result: any, response: Array<any>): boolean => {
         $('#userSearch').search('hide results');
-        $('#userSearchInput').val(displayName);
 
-        this.newCollabUser = result;
-        this.ref.detectChanges();
+        // Async callback looks up displayName from the input to set the user
+        setTimeout(() => {
+          const displayName: string = $('#userSearch').search('get value');
+          const displayResult: User = filteredUsers.find(u => u.name === displayName);
 
+          if (displayResult) {
+            this.newCollabUser = displayResult;
+          } else {
+            this.logger.error('Failed to select search result: ', displayName)
+          }
+
+          this.ref.detectChanges();
+        }, 300);
+
+        // Must return true here to set selected name as the input value
         return true;
       }
     });
-
-    this.ref.detectChanges();
   }
 
   ngOnChanges(): void {

--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -60,8 +60,8 @@
         <td [title]="ele.name">{{ ele.name | truncate:100 }}</td>
         <td *ngIf="ele.runStatus !== undefined">
           <span *ngIf="ele.runStatus === 0"><i class="fa fa-fw fa-question yellow"></i> UNKNOWN</span>
-          <span *ngIf="ele.runStatus === 1"><i class="fa fa-fw fa-spinner fa-pulse blue"></i> STARTING</span>
-          <span *ngIf="ele.runStatus === 2"><i class="fa fa-fw fa-refresh fa-spin blue"></i> RUNNING</span>
+          <span *ngIf="ele.runStatus === 1"><i class="fa fa-fw fa-spinner fa-pulse yellow"></i> STARTING</span>
+          <span *ngIf="ele.runStatus === 2"><i class="fa fa-fw fa-sync-alt fa-spin blue"></i> RUNNING</span>
           <span *ngIf="ele.runStatus === 3"><i class="fa fa-fw fa-check green"></i> COMPLETED</span>
           <span *ngIf="ele.runStatus === 4"><i class="fa fa-fw fa-times red"></i> FAILED</span>
           <span *ngIf="ele.runStatus === 5"><i class="fa fa-fw fa-ban red"></i> CANCELLED</span>

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -119,11 +119,12 @@ export class FileExplorerComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (
-      changes?.path?.currentValue !== changes?.path?.previousValue || // if path changes
-      changes?.currentNav?.currentValue !== changes?.currentNav?.previousValue || // if selected nav changes
+      // if path or selected nav changes
+      changes?.path?.currentValue !== changes?.path?.previousValue ||
+      changes?.currentNav?.currentValue !== changes?.currentNav?.previousValue || 
+      // if a new file is uploaded
       changes?.fileElements?.currentValue?.length !== changes?.fileElements?.previousValue?.length
     ) {
-      // if a new file is uploaded
       setTimeout(() => {
         $('.ui.file.dropdown').dropdown({ action: 'hide' });
       }, 500);

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -118,7 +118,12 @@ export class FileExplorerComponent implements OnChanges {
   constructor(private readonly dialog: MatDialog, private readonly logger: LogService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.path || changes.currentNav || changes.fileElements) {
+    if (
+      changes?.path?.currentValue !== changes?.path?.previousValue || // if path changes
+      changes?.currentNav?.currentValue !== changes?.currentNav?.previousValue || // if selected nav changes
+      changes?.fileElements?.currentValue?.length !== changes?.fileElements?.previousValue?.length
+    ) {
+      // if a new file is uploaded
       setTimeout(() => {
         $('.ui.file.dropdown').dropdown({ action: 'hide' });
       }, 500);

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -15,7 +15,7 @@ declare var $: any;
 @Component({
   selector: 'app-notification-stream',
   templateUrl: './notification-stream.component.html',
-  styleUrls: ['./notification-stream.component.scss']
+  styleUrls: ['./notification-stream.component.scss'],
 })
 export class NotificationStreamComponent {
   constructor(
@@ -115,7 +115,7 @@ export class NotificationStreamComponent {
 
     this.zone.run(() => {
       // Check for existing notifications matching this one
-      const existing = this.events.find(evt => eventData._id === evt._id);
+      const existing = this.events.find((evt) => eventData._id === evt._id);
       if (!existing) {
         // If we haven't seen one like this, then display it
         this.notificationStream.events.push(eventData);
@@ -134,9 +134,14 @@ export class NotificationStreamComponent {
       this.zone.runOutsideAngular(() => {
         $(`#event-progress-${eventData._id}`).progress({
           total: eventData.data.total,
-          value: eventData.data.current
+          value: eventData.data.current,
         });
       });
+    }
+
+    // If task has related resources, attempt to update them too
+    if (eventData.data.resource.type === 'wt_recorded_run') {
+      return this.sync.taleUpdated(eventData.data.resource.tale_id);
     }
 
     this.ref.detectChanges();
@@ -152,7 +157,7 @@ export class NotificationStreamComponent {
     // Grab first (build) jobId
     const jobIds = event.data.resource.jobs;
     const config: MatDialogConfig = {
-      data: { jobIds }
+      data: { jobIds },
     };
 
     const dialogRef = this.dialog.open(ViewLogsDialogComponent, config);

--- a/src/app/shared/core/window.service.ts
+++ b/src/app/shared/core/window.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { ApiConfiguration } from '@api/api-configuration';
 import { LogService } from '@shared/core/log.service';
 
 import { Window } from './models/window';
@@ -12,26 +13,27 @@ export class WindowService implements Window {
   location: any = {};
   env: any = {};
 
-  constructor(private readonly http: HttpClient, private readonly logger: LogService) {
+  constructor(private readonly http: HttpClient, private readonly config: ApiConfiguration, private readonly logger: LogService) {
     this.http.get(ENV_URL).subscribe(
-      env => {
+      (env: any) => {
         this.env = env;
+        this.config.rootUrl = env.apiUrl;
       },
-      err => {
+      (err) => {
         this.logger.error('Failed to fetch env: ', err);
       }
     );
   }
 
   open(url: string, target?: string): void {
-    return;
+    window.open(url, target);
   }
 
   alert(msg: string): void {
-    return;
+    window.alert(msg);
   }
 
   confirm(msg: string): void {
-    return;
+    window.confirm(msg);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,20 +3696,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001032:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
-
-caniuse-lite@^1.0.30000981:
-  version "1.0.30001243"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz#d9250155c91e872186671c523f3ae50cfc94a3aa"
-  integrity sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==
-
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001230"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001032, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
+  version "1.0.30001302"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz"
+  integrity sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==
 
 canonical-path@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Problem
Various small bugs that have been filed recently

Fixes #241 
Fixes #240 
Fixes #237 
Fixes #236 
Fixes #235 


## Approach
* Updated `caniuse` for more accurate browser compatibility hints (this was recommended by our CLI build tools)
* #241: Fixed missing icon for RunStatus.RUNNING - `fa-refresh` no longer appear to work as they did in previous versions of FontAwesome, so `fa-sync` or `fa-sync-alt` should be used instead
* #240: Fixed Export dropdown option for Tale Version on Tale History Panel - `windowService.open` was no longer working as expected
* #237: Fixed `apiUrl` being ignored - the `apiUrl` from `env.json` should once again reflect in the API calls (see note below)
* #236: Fixed "Add" button always being disabled on Run > Share - I suspect that an upgrade might have broken this.. entire method signature appeared different, so some new logic was required here
* #235: Fixed Run > Files dropdown behavior - better change-handling means that this dropdown will only close if something actually changes (e.g. if user changes navs, if user changes the current folder, or if the user uploads a new file to the current folder)


A note about #237 
Because this `apiUrl` needs to be passed into the `ApiModule` on bootstrap, I experimented with a few different patterns using Angular's `APP_INITIALIZERS`, but nothing seemed to provide a smart async method for setting this up after runtime. In the end, I ended up just applying the new `apiUrl` directly from the fetched env (in `WindowService`) onto the existing `ApiConfiguration`. this is probably an anti-pattern for some silly angular reason, but their recommended pattern was overly complex and did not give the correct results, so I'm ok with this 1-line hack if it appears to fix the problem


## How to Test
Prerequisites: at least one Tale created, at least one Version created, ability to Run the Tale

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Files > Recorded Runs for a Tale that you own
4. Create a new Run and wait for it to reach the `RUNNING` state (#241)
    * You should see the spinning arrow icons for the RUNNING state
5. Expand the Tale History Panel on the right and create a new version (if you haven't already)
6. On the timeline below, expand the dropdown beside the new version and choose Export (#240)
    * You should see a new tab open briefly, then close itself, and your file download should begin
7. Edit `env.json` manually, set `apiUrl` to `https://google.com`, save the file, then refresh the UI (#237)
    * You should see many errors in the console, as google.com is not recognized as a valid WholeTale instance
8. Navigate to Run > Share and share with a new user (#236)
    * You should see that the Add button is enabled once a user has been selected from the search prompt
9. Navigate to Run > Files > Tale Workspace and upload a few files to the workspace
10. Expand the dropdown beside one of these files (#235)
    * You should see that the dropdown is more stable, and stays open long enough for the user to actually read the options and interact with it