### PR TITLE
Tale Version Panel fixes: orderby created date, link directly to runs/versions

### DIFF
--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -51,14 +51,19 @@
           </div>
         </div>
         <div class="content">
-          <div class="date">{{ res.updated | date:'short' }}</div>
+          <div class="date">{{ res.created | date:'short' }}</div>
           <div class="header">
             <img class="ui avatar image" *ngIf="(res | taleCreator | async) as creator" [src]="creator.gravatar_baseUrl" title="{{ creator.firstName }} {{ creator.lastName }} ({{ creator.login }})" />
+
             <span *ngIf="!res.runVersionId">Version saved:</span>
             <span *ngIf="res.runVersionId">Recorded run:</span>
           </div>
 
-          {{ res.name }}
+          <a href="#" [routerLink]="'/run/' + tale._id"
+             [queryParams]="{ 'tab': 'files', 'nav': res.runVersionId ? 'recorded_runs' : 'tale_versions', 'highlight': res._id }"
+             routerLinkActive="active">
+            {{ res.name }}
+          </a>
 
           <p>
             <small *ngIf="res.runVersionId">

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -71,7 +71,7 @@
               <a href="#" [routerLink]="'/run/' + tale._id"
                  [queryParams]="{ 'tab': 'files', 'nav': 'tale_versions', 'highlight': res.runVersionId }"
                  routerLinkActive="active">
-                {{ res.runVersionId | versionName | async }}
+                {{ res.runVersionId | versionName:timeline }}
               </a>
             </small>
           </p>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -79,6 +79,12 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
         this.refresh();
       }
     });
+
+    this.versionsSubscription = this.syncService.taleUpdatedSubject.subscribe((taleId) => {
+      if (taleId === this.tale._id) {
+        this.refresh();
+      }
+    });
   }
 
   ngOnChanges(): void {
@@ -96,7 +102,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
   refresh(): void {
     this.versionService.versionListVersions({ taleId: this.tale._id }).subscribe((versions: Array<Version>) => {
       this.runService.runListRuns({ taleId: this.tale._id }).subscribe((runs: Array<Run>) => {
-        this.timeline = versions.concat(runs).sort(this.sortByUpdatedDate);
+        this.timeline = versions.concat(runs).sort(this.sortByCreatedDate);
         this.ref.detectChanges();
       });
     });
@@ -113,9 +119,9 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
    * @param a First version to compare
    * @param b Second version to compare
    */
-  sortByUpdatedDate(a: Version, b: Version): number {
-    const dateA = new Date(a.updated);
-    const dateB = new Date(b.updated);
+  sortByCreatedDate(a: Version, b: Version): number {
+    const dateA = new Date(a.created);
+    const dateB = new Date(b.created);
     if (dateA < dateB) {
       return 1;
     } else if (dateA > dateB) {

--- a/src/app/tales/pipes/tale-version-name.pipe.ts
+++ b/src/app/tales/pipes/tale-version-name.pipe.ts
@@ -1,15 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Run } from '@api/models/run';
 import { Version } from '@api/models/version';
-import { VersionService } from '@api/services/version.service';
-import { EMPTY, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 // Given a taleId, fetch and return the Tale's title
 @Pipe({ name: 'versionName' })
 export class TaleVersionNamePipe implements PipeTransform {
-  constructor(private readonly versionService: VersionService) {}
-
   transform(versionId: string, timeline: Array<Version | Run>): string {
     if (!versionId) {
       return '...';
@@ -17,14 +12,16 @@ export class TaleVersionNamePipe implements PipeTransform {
 
     // return this.versionService.versionGetVersion(versionId).pipe(map((v: Version) => v.name))
     const version = timeline.find((evt) => {
-      // Skip runs, only looking for versions
       if ('runVersionId' in evt) {
+        // Skip runs, we're only looking for versions
         return false;
       }
 
+      // This is a version.. but does its id match?
       return versionId === evt._id;
     });
 
+    // Return the version's name, if applicable
     return version?.name || 'N / A';
   }
 }

--- a/src/app/tales/pipes/tale-version-name.pipe.ts
+++ b/src/app/tales/pipes/tale-version-name.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { Run } from '@api/models/run';
 import { Version } from '@api/models/version';
 import { VersionService } from '@api/services/version.service';
 import { EMPTY, Observable } from 'rxjs';
@@ -9,11 +10,21 @@ import { map } from 'rxjs/operators';
 export class TaleVersionNamePipe implements PipeTransform {
   constructor(private readonly versionService: VersionService) {}
 
-  transform(versionId: string): Observable<string> {
+  transform(versionId: string, timeline: Array<Version | Run>): string {
     if (!versionId) {
-      return EMPTY;
+      return '...';
     }
 
-    return this.versionService.versionGetVersion(versionId).pipe(map((v: Version) => v.name));
+    // return this.versionService.versionGetVersion(versionId).pipe(map((v: Version) => v.name))
+    const version = timeline.find((evt) => {
+      // Skip runs, only looking for versions
+      if ('runVersionId' in evt) {
+        return false;
+      }
+
+      return versionId === evt._id;
+    });
+
+    return version?.name || 'N / A';
   }
 }


### PR DESCRIPTION
## Problem
Fixes #234 

## Approach
* Order by `created` date, instead of `updated` date
* ??? - fix for the rename issue may need backend signal work, or else the `SyncService` is missing some implementation
* Link to Run > Files > Tale Versions and/or Run > Files > Recorded Runs directly from the Tale History Panel

## How to Test
Prerequisites: at least on Tale created, at least one Tale Version created, at least one Run created from the Version

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run Tale and create a Version and a Run (if you haven't already
4. Expand the Tale History Panel and view the timeline
   * You should see timeline is now sorted by `created` date
   * You should see that the version/run name is now a link
5. Rename the version
    * You should see the order does not change in the list (e.g. the run should be created after version, no matter what) 
6. Click on the version name
    * You should be brought to Run > Files > Tale Versions with the chosen version highlighted
6. Click on the run name
    * You should be brought to Run > Files > Recorded Runs with the chosen run highlighted