### PR TITLE
Fix AiWT URL encoding / roll-back when rename fails

### DIFF
--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -744,6 +744,9 @@ export class TaleFilesComponent implements OnInit, OnChanges {
       this.runService.runPutRenameRun(params.id, params.name).subscribe(resp => {
         this.load();
       }, err => {
+        // Rename failed, roll-back the change
+        element.name = element.prevName;
+        this.ref.detectChanges();
         this.dialog.open(ErrorModalComponent, { data: { error: err.error } });
       });
 
@@ -757,6 +760,9 @@ export class TaleFilesComponent implements OnInit, OnChanges {
       this.versionService.versionPutRenameVersion(params.id, params.name).subscribe(resp => {
         this.load();
       }, err => {
+        // Rename failed, roll-back the change
+        element.name = element.prevName;
+        this.ref.detectChanges();
         this.dialog.open(ErrorModalComponent, { data: { error: err.error } });
       });
 
@@ -774,6 +780,9 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         folders[index] = resp;
         this.folders.next(folders);
       }, err => {
+        // Rename failed, roll-back the change
+        element.name = element.prevName;
+        this.ref.detectChanges();
         this.dialog.open(ErrorModalComponent, { data: { error: err.error } });
       });
     } else if (element._modelType === 'item') {
@@ -787,6 +796,9 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         files[index] = resp;
         this.files.next(files);
       }, err => {
+        // Rename failed, roll-back the change
+        element.name = element.prevName;
+        this.ref.detectChanges();
         this.dialog.open(ErrorModalComponent, { data: { error: err.error } });
       });
     }

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, Inject, NgZone, OnInit } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Image, Tale } from '@api/models';
 import { ImageService } from '@api/services';
 import { LogService, WindowService } from '@shared/core';
@@ -31,7 +31,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       private readonly window: WindowService
     ) {
     this.newTale = {
-      title: (data && data.params) ? data.params.name : '',
+      title: (data && data.params) ? decodeURIComponent(data.params.name) : '',
       imageId: '',
       authors: [],
       licenseSPDX: 'CC-BY-4.0',
@@ -43,7 +43,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       description: '### Provide a description for your Tale'
     };
     this.showGit = data.showGit;
-    this.baseUrl = (data && data.params && data.params.api) ? data.params.api : '';
+    this.baseUrl = (data && data.params && data.params.api) ? decodeURIComponent(data.params.api) : '';
   }
 
   ngOnInit(): void {
@@ -71,7 +71,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
     if (this.data && this.data.params && this.data.params.uri) {
       this.zone.run(() => {
         // TODO: Fetch / display data citation from datacite?
-        this.datasetCitation = { doi: this.data.params.uri };
+        this.datasetCitation = { doi: decodeURIComponent(this.data.params.uri) };
       });
 
       // Set read/write radio buttons using asTale value
@@ -91,7 +91,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
         // If user specified an environment as a parameter, select it by default
         if (this.data && this.data.params && this.data.params.environment) {
           // Search for matching name
-          const match = this.environments.find(env => env.name === this.data.params.environment);
+          const match = this.environments.find(env => env.name === decodeURIComponent(this.data.params.environment));
           if (match) {
             // If found, select it in the dropdown
             this.newTale.imageId = match._id;
@@ -106,7 +106,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
   }
 
   enableReadOnly(evt: any): void {
-    this.logger.info("Enabling read only on this Tale...");
+    this.logger.debug("Enabling read only on this Tale...");
     const target = evt.target;
     if (target.checked) {
       this.asTale = false;
@@ -114,7 +114,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
   }
 
   enableReadWrite(evt: any): void {
-    this.logger.info("Enabling read/write on this Tale...");
+    this.logger.debug("Enabling read/write on this Tale...");
     const target = evt.target;
     if (target.checked) {
       this.asTale = true;

--- a/src/app/api/models/run.ts
+++ b/src/app/api/models/run.ts
@@ -18,6 +18,7 @@ export interface Run {
 
   // Unique properties
   name: string;
+  prevName: string; // for rolling back failed rename
   description: string;
   isMapping: boolean;
   public: boolean;

--- a/src/app/api/models/version.ts
+++ b/src/app/api/models/version.ts
@@ -41,6 +41,7 @@ export interface Version {
   created: Date;
   creatorId: string;
   description: string;
+  prevName: string; // for rolling back failed rename
   name: string;
   parentCollection: string;
   parentId: string;

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -121,7 +121,7 @@ export class FileExplorerComponent implements OnChanges {
     if (
       // if path or selected nav changes
       changes?.path?.currentValue !== changes?.path?.previousValue ||
-      changes?.currentNav?.currentValue !== changes?.currentNav?.previousValue || 
+      changes?.currentNav?.currentValue !== changes?.currentNav?.previousValue ||
       // if a new file is uploaded
       changes?.fileElements?.currentValue?.length !== changes?.fileElements?.previousValue?.length
     ) {
@@ -231,6 +231,7 @@ export class FileExplorerComponent implements OnChanges {
     dialogRef.afterClosed().subscribe((res) => {
       if (res) {
         this.logger.debug(`Folder renamed: ${element.name} -> ${res}`);
+        element.prevName = element.name;
         element.name = res;
         this.elementRenamed.emit(element);
       }

--- a/src/app/files/models/file-element.ts
+++ b/src/app/files/models/file-element.ts
@@ -9,6 +9,7 @@ export interface FileElement {
   name: string;
   size: number;
   updated: Date;
+  prevName: string;
 
   // upload progress
   uploadProgress?: number;
@@ -46,6 +47,7 @@ export class FileElement implements FileElement {
   created: Date = new Date();
   description = '';
   name: string;
+  prevName = ''; // for rolling back failed rename
   size = 0;
   updated: Date = new Date();
 


### PR DESCRIPTION
## Problem
Fixes #249 - If renaming a file or folder, the UI shows the new name as if it were successful
Fixes #250 - If a user is not logged in and attempts to trigger AiWT, their URL parameters are double-encoded and are not properly decoded

## Approach
* #249: store `prevName` when renaming, roll-back to this name if the rename fails
* #250: decode all params for AiWT (in case they are double-encoded by the login redirect)

## How to Test

### Testing #249
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Navigate to Run > Files (Home or Workspace) for a Tale that you own
3. Create a folder named `folder1`
4. Create a second folder named `folder`
5. Attempt to rename `folder2` to `folder1`
    * You should see that an error modal appears on the screen indicating that the rename has failed
    * You should see the previous name `folder2` is restored
    * You should **NOT** see two listings named `folder1`

### Testing #250
1. Checkout this branch locally, rebuild the dashboard
2. Close all incognito windows, then open a fresh incognito window
3. Navigate to https://dashboard.local.wholetale.org/browse?uri=https%3A%2F%2Fdoi.org%2F10.5281%2Fzenodo.820575&name=Automotive%20Sensor%20Data
    * You should be redirected to login
    * Notice the URL parameters are double-encoded
4. Click "Access WholeTale" and log in
    * After login, you should be redirected to the "My Tales" part of the Tale Catalog
    * You should see the Create Tale Modal automatically open
    * You should see that the `Name` field is pre-populated and that the value is not URL encoded
5. Look toward the bottom of the modal
    * You should see that the `Data Source` is populated with a URL that is properly encoded (e.g. only suffix is encoded, URL part should be readable)