### PR TITLE
Add tooltips to textless buttons

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -87,11 +87,11 @@
                         </a>
 
                         <div class="right menu">
-                            <a *ngIf="instance && instance.status === 1 && currentTab === 'interact'" id="popout-link" class="item" [href]="instance.url" target="_blank">
+                            <a *ngIf="instance && instance.status === 1" id="popout-link" class="item" [href]="instance.url" target="_blank" matTooltip="Open in separate tab or window">
                                 <i class="fas fa-fw fa-external-link-alt"></i>
                             </a>
 
-                            <a class="item" *ngIf="tale._accessLevel >= AccessLevel.Read" (click)="toggleVersionsPanel()">
+                            <a class="item" *ngIf="tale._accessLevel >= AccessLevel.Read" (click)="toggleVersionsPanel()" matTooltip="Show or hide Tale history">
                                 <i class="fas fa-history lighter"></i>
                             </a>
                         </div>

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -11,7 +11,7 @@
       <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" title="Report a Problem" target="_blank" matTooltip="Report a problem">
         <i class="bug white icon"></i>
       </a>
-      <a class="item" (click)="toggleNotificationStream()" title="Events and Notifications" matTooltip="Events and notifications">
+      <a class="item" (click)="toggleNotificationStream()" matTooltip="Events and notifications">
         <i class="tasks white icon"></i>
         <div id="event-notification-counter" class="floating ui red label" *ngIf="eventCount > 0">
             {{ eventCount }}

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -8,7 +8,7 @@
         <a class="item" [href]="docUrl" title="Users' Guide" target="_blank" matTooltip="Open user's guide">
         <i class="info circle white icon"></i>
       </a>
-      <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" title="Report a Problem" target="_blank" matTooltip="Report a problem">
+      <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" target="_blank" matTooltip="Report a problem">
         <i class="bug white icon"></i>
       </a>
       <a class="item" (click)="toggleNotificationStream()" matTooltip="Events and notifications">

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,19 +5,19 @@
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
-      <a class="item" [href]="docUrl" title="Users' Guide" target="_blank">
+        <a class="item" [href]="docUrl" title="Users' Guide" target="_blank" matTooltip="Open user's guide">
         <i class="info circle white icon"></i>
       </a>
-      <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" title="Report a Problem" target="_blank">
+      <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" title="Report a Problem" target="_blank" matTooltip="Report a problem">
         <i class="bug white icon"></i>
       </a>
-      <a class="item" (click)="toggleNotificationStream()" title="Events and Notifications">
+      <a class="item" (click)="toggleNotificationStream()" title="Events and Notifications" matTooltip="Events and notifications">
         <i class="tasks white icon"></i>
         <div id="event-notification-counter" class="floating ui red label" *ngIf="eventCount > 0">
             {{ eventCount }}
         </div>
       </a>
-      <div class="ui right account dropdown link item">
+      <div class="ui right account dropdown link item" matTooltip="User menu" >
         <span class="text">
             <img *ngIf="user?.gravatar_baseUrl" class="ui avatar image gravatar" [src]="user.gravatar_baseUrl">
             <i *ngIf="!user?.gravatar_baseUrl" class="user circle white icon"></i>

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,7 +5,7 @@
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">
-        <a class="item" [href]="docUrl" title="Users' Guide" target="_blank" matTooltip="Open user's guide">
+        <a class="item" [href]="docUrl" target="_blank" matTooltip="Open user's guide">
         <i class="info circle white icon"></i>
       </a>
       <a class="item" href="https://github.com/whole-tale/whole-tale/issues/new/choose" target="_blank" matTooltip="Report a problem">


### PR DESCRIPTION
## Problem
Per evaluator feedback (https://github.com/whole-tale/whole-tale/issues/112):  "It would be nice if when you hovered over a symbol (like the box with the arrow coming out of it in the upper right) it would give you a little text saying what it did, rather than just having to click the button and see what happens. " (4)

I went ahead and added tooltips for more than just the pop-out.

## Approach
* Added tooltips

## How to Test
* Hover over the header icons (docs, bug, notifications, user menu) and the tale pop-out and history icons. Tooltips should display.