### PR TITLE
Disable export menu option if not writable

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -59,7 +59,7 @@
 
                                             <div class="item" (click)="copyTale()"><i class="fas fa-fw fa-clone"></i> Duplicate Tale</div>
                                             <div class="item" (click)="openPublishTaleDialog($event)" *ngIf="isTaleWritable()"><i class="fas fa-fw fa-newspaper"></i> Publish Tale</div>
-                                            <div class="item" (click)="exportTale()"><i class="fas fa-fw fa-file-archive"></i> Export Tale</div>
+                                            <div class="item" (click)="exportTale()" *ngIf="isTaleWritable()"><i class="fas fa-fw fa-file-archive"></i> Export Tale</div>
                                             <div class="divider" *ngIf="isTaleWritable()"></div>
                                             <div class="item" (click)="openConnectGitRepoDialog()" *ngIf="isTaleWritable()"><i class="fab fa-fw fa-git"></i> Connect to Git Repository...</div>
                                             <div class="divider"></div>


### PR DESCRIPTION
See https://github.com/whole-tale/ngx-dashboard/issues/260 for test case

This PR simply disables the Export menu as we already do publish. Another option would be to prompt the user to copy the tale.