### PR TITLE
fix: rename/upload shouldnt break the file context menu

### DIFF
--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -289,6 +289,10 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         // Can't bind to [attr.data-percent].. use js to set total and update progress
         $(`#upload-${uploadId}`).progress('set percent', 100);
         initResp.uploading = false;
+
+        setTimeout(() => {
+          $('.ui.file.dropdown').dropdown({ action: 'hide' });
+        }, 500);
         this.ref.detectChanges();
 
         // This is apparently not needed all the time? Files are weird...
@@ -778,6 +782,10 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         const index = folders.indexOf(element);
         folders[index] = resp;
         this.folders.next(folders);
+        
+        setTimeout(() => {
+          $('.ui.file.dropdown').dropdown({ action: 'hide' });
+        }, 500);
       }, err => {
         // Rename failed, roll-back the change
         element.name = element.prevName;
@@ -794,6 +802,10 @@ export class TaleFilesComponent implements OnInit, OnChanges {
         const index = files.indexOf(element);
         files[index] = resp;
         this.files.next(files);
+
+        setTimeout(() => {
+          $('.ui.file.dropdown').dropdown({ action: 'hide' });
+        }, 500);
       }, err => {
         // Rename failed, roll-back the change
         element.name = element.prevName;


### PR DESCRIPTION
## Problem
After performing a rename or upload, the file's context dropdown menu breaks.

Fixes #259

## Approach
The last fix to this logic changed things so that it only looks at the length of the list to perform these updates. An upload completing itself and a rename are two cases where the length of the list stays the same.

Added some additional post-upload and post-rename logic to force this context menu to work after the upload/rename is complete - NOTE: when this fires, it will cause all dropdowns similar to the behavior we saw before. If the user is uploading many small files, they may run into behavior like before, where the menu is not open long enough to interact with it.

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Files > Home
4. Upload a file
    * You should see the new upload appear in the list
5. Expand the context menu to the right of the in-progress upload
    * You should see the menu opens as expected
6. Wait for the upload to complete
    * If the menu is still open, you should see it automatically close here
7. Expand the context menu to the right of the completed upload
    * You should see the menu still opens as expected
8. Rename the completed upload and attempt to expand the menu once more
    * You should see the menu still opens as expected