### PR TITLE
Ensure correct file manager nav contents

### DIFF
--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.html
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.html
@@ -49,7 +49,7 @@
 
 
       <app-file-explorer id="tale-files-browser"
-        [fileElements]="(folders | async).concat(files | async)"
+        [fileElements]="folders.value.concat(files.value)"
         [path]="currentPath"
         [highlighted]="highlighted"
         [placeholderMessage]="placeholderMessage"

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -78,12 +78,6 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
         this.refresh();
       }
     });
-
-    this.versionsSubscription = this.syncService.taleUpdatedSubject.subscribe((taleId) => {
-      if (taleId === this.tale._id) {
-        this.refresh();
-      }
-    });
   }
 
   ngOnChanges(): void {
@@ -93,9 +87,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   ngOnDestroy(): void {
-    if (this.versionsSubscription) {
-      this.versionsSubscription.unsubscribe();
-    }
+    this.versionsSubscription?.unsubscribe();
   }
 
   refresh(): void {

--- a/src/app/api/token.service.ts
+++ b/src/app/api/token.service.ts
@@ -5,7 +5,7 @@ import { User } from '@api/models/user';
 import { UserService } from '@api/services/user.service';
 import { JwtHelperService } from '@auth0/angular-jwt';
 import { LogService } from '@shared/core/log.service';
-import { ReplaySubject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class TokenService {
@@ -15,7 +15,7 @@ export class TokenService {
   returnRoute: string;
 
   // Cache the user that this token represents (for display)
-  user: ReplaySubject<User> = new ReplaySubject<User>();
+  user: BehaviorSubject<User> = new BehaviorSubject<User>(undefined);
 
   constructor(private readonly userService: UserService, private readonly logger: LogService) {}
 
@@ -57,11 +57,11 @@ export class TokenService {
     if (!isExpired) {
       this.logger.debug(`Token not yet expired - checking Girder for validity`);
       this.userService.userGetMe().subscribe(
-        user => {
+        (user) => {
           this.logger.debug('Fetched user:', user);
           this.user = user;
         },
-        err => {
+        (err) => {
           this.logger.error(`Failed to fetch the currently logged-in user`);
         }
       );

--- a/src/app/shared/core/base.component.ts
+++ b/src/app/shared/core/base.component.ts
@@ -1,15 +1,15 @@
 import { Component, OnDestroy } from '@angular/core';
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 @Component({
-  template: ''
+  template: '',
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BaseComponent implements OnDestroy {
-  protected ngUnsubscribe: Subject<void>;
+  protected ngUnsubscribe: BehaviorSubject<void>;
 
   constructor() {
-    this.ngUnsubscribe = new Subject<void>();
+    this.ngUnsubscribe = new BehaviorSubject<void>(undefined);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Problem
The UI can sometimes show incorrect content after loading. My current thinking is that request timing is a problem here, and we are possibly fulfilling requests out of order due to their timing.

This also attempts to fix avalanching requests when switching tabs on Run Tale (@Xarthisius reproduced this during the 3/7 dev meeting)

Fixes #261 

## Approach
* Add conditionals to the Run > Files view - ignore requests that aren't for our current nav when the request finishes
    * e.g. if we ask for External Data, then switch to Workspace, do not render the results of the fetch for the External Data
* In addition, I audited our usage of Subject/. Subscription in many places and tried to ensure that there is an unsubscribe everywhere that it is needed
    * NOTE: we **only** need to call `unsubscribe()` for long-running data streams (e.g. subscriptions to syncService), but unsubscribe is not needed for one-off HTTP calls. This makes it very confusing to audit thoroughly and very easy to overlook, as it is quite situational.

## How to Test
Prerequisites: at least one Tale created

#### Avalanching Requests
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Files > External Data
4. Open the developer console
5. Click to Metadata, clear the Console, and click back to Files
    * Note the number of requests being sent here
6. Repeat step 5 and verify that the request count is the same, and has not increased


#### #261 File Manager sometimes shows wrong content
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Files > External Data
4. Try really hard to break things - click around navs quickly, into subfolders, etc
    * Please make note of any odd behavior, and attempt as much as possible to reproduce it