### PR TITLE
Add accessibility features to the login page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,22 @@
 import { Component } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
 import { BaseComponent } from '@shared/core';
 
 @Component({
   selector: 'app-root',
-  templateUrl: './app.component.html'
+  templateUrl: './app.component.html',
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AppComponent extends BaseComponent {}
+export class AppComponent extends BaseComponent {
+  constructor(private readonly titleService: Title, private readonly metaService: Meta) {
+    super();
+    this.setTitle('WholeTale Dashboard');
+    this.metaService.updateTag({
+      name: 'description',
+      content: 'Changing meta tags using an Angular service',
+    });
+  }
+  setTitle(newTitle: string): void {
+    this.titleService.setTitle(newTitle);
+  }
+}

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,11 +1,13 @@
 <!-- Fake navbar (yuck) -->
-<div class="ui inverted menu wt top">
-  <div class="header item wt brand"><img src="../../assets/img/wholetale_logo_sm.png">WHOLE<span>TALE</span> <span> Dashboard</span></div>
+
+<div class="ui inverted menu wt top" role="heading">
+  <a href="/login#start-of-content" class="show-on-focus js-skip-to-content">Skip to content</a>
+  <div class="header item wt brand"><img src="../../assets/img/wholetale_logo_sm.png" alt="Whole Tale Logo">WHOLE<span>TALE</span> <span> Dashboard</span></div>
 </div>
 
 <!-- Styled login area -->
 <div class="login area">
-  <div class="login banner">
+  <div class="login banner" role="banner">
     <div class="ui huge white header">Reproducibility Simplified</div>
 
     <div class="ui white header">
@@ -13,15 +15,27 @@
         <p class="nomargin">reproducible computational research. <a href="https://wholetale.org" style="color:white;"><u>Learn more...</u></a></p>
     </div>
   </div>
+  <div id="start-of-content" class="show-on-focus"></div>
+  <div role="main">
+    <div style="margin-top: 10vh; margin-bottom: 2vh; color: black;">
+      <h1>
+        Sign in to Whole Tale
+      </h1>
+    </div>
 
-  <a class="ui large blue button" (click)="loginWithGlobus()">
-    <div class="access-wholetale">Access</div>
-    <img src="../../assets/img/whole_tale_logo_text_long_light_large.png" width="200px" style="width:200px">
-  </a>
+    <a class="ui github-button button" (click)="loginWithGirder('GitHub')" (keydown.enter)="loginWithGirder('GitHub')" role="button" tabindex="0">
+      <i class="github icon github-button-icon"></i>
+      Sign in with GitHub
+    </a>
+    <a class="ui globus-button button" (click)="loginWithGirder('Globus')" (keydown.enter)="loginWithGirder('Globus')" role="button" tabindex="0">
+      <i class="fa-globe icon globus-button-icon"></i>
+      Sign in with Globus
+    </a>
 
-  <p style="botmargin" style="margin: 10px; color:black;">By accessing Whole Tale, you agree to our
-    <a [href]="tosUrl" style="color:black" target="_blank"><u>Terms of Use</u></a>.
-  </p>
+    <p style="botmargin" style="margin: 10px; color:black;">By accessing Whole Tale, you agree to our
+      <a [href]="tosUrl" style="color:black" target="_blank"><u>Terms of Use</u></a>.
+    </p>
+  </div>
 
   <div style="color:black">
     <p class="nomargin" style="margin-top: 50px; font-size: 12pt;">Whole Tale is supported by the National Science Foundation under Grant No. OAC-1541450.</p>
@@ -31,7 +45,7 @@
 </div>
 
 <!-- Fake footer -->
-<div class="ui centered footer grid">
+<div class="ui centered footer grid" role="contentInfo">
   <div class="ui inverted basic blue segment row">
     <div class="three wide column"></div>
 

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -40,6 +40,30 @@
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
+.ui.globus-button {
+  background-color: #2b5693;
+  border: 1px solid #1e3c66;
+  color: white;
+  &:hover {
+    background-color: #24497c;
+  }
+  .globus-button-icon {
+    border-right-color: #1e3c66;
+  }
+}
+
+.ui.github-button {
+  background-color: #333333;
+  border: 1px solid #232323;
+  color: white;
+  &:hover {
+    background-color: #2b2b2b;
+  }
+  .github-button-icon {
+    border-right-color: #232323;
+  }
+}
+
 .ui.blue.button {
   margin-top: 10vh;
   background-color: #0075d8;
@@ -165,4 +189,36 @@ body .ui.inverted.menu {
 .item,
 p {
   font-size: 1em;
+}
+
+// Only display content to screen readers
+//
+// See: http://a11yproject.com/posts/how-to-hide-content/
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
+  word-wrap: normal;
+  border: 0;
+}
+
+// Only display content on focus
+.show-on-focus {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+
+  &:focus {
+    z-index: 20;
+    width: auto;
+    height: auto;
+    clip: auto;
+  }
 }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { OauthService } from '@api/services/oauth.service';
 import { UserService } from '@api/services/user.service';
@@ -31,9 +32,16 @@ export class LoginComponent extends BaseComponent implements OnInit {
     private readonly oauth: OauthService,
     private readonly cookies: CookieService,
     private readonly users: UserService,
-    private readonly tokenService: TokenService
+    private readonly tokenService: TokenService,
+    private readonly titleService: Title,
+    private readonly metaService: Meta
   ) {
     super();
+    this.titleService.setTitle('Sign in to WholeTale');
+    this.metaService.updateTag({
+      name: 'description',
+      content: 'Whole Tale, an open source platform for reproducible computational research.',
+    });
   }
 
   ngOnInit(): void {
@@ -97,14 +105,14 @@ export class LoginComponent extends BaseComponent implements OnInit {
     window.location.href = href;
   }
 
-  loginWithGlobus(): void {
+  loginWithGirder(provider: string): void {
     const route = this.tokenService.getReturnRoute();
 
     // FIXME: is it ok to use window.location.origin here?
     const params = { redirect: `${window.location.origin}/login?token={girderToken}&rd=${route}`, list: false };
     this.oauth.oauthListProviders(params).subscribe(
       (providers: any) => {
-        window.location.href = providers[window.env.authProvider];
+        window.location.href = providers[provider];
       },
       (err) => {
         this.logger.error('Failed to GET /oauth/providers:', err);

--- a/src/index.html
+++ b/src/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <base href="/">
     <meta charset="utf-8"/>
     <title></title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-
+    <meta name="description" content="Whole Tale, an open source platform for reproducible computational research.">
     <script src="assets/env.js"></script>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,600,700,800&amp;subset=latin-ext">
     <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
## Problem

Our current login page makes it practically impossible to navigate (and login) using screen readers, more over our main oauth provider (Globus) makes it impossible to select university specific auth provider.

## Approach
1. Add a structure to the login page ("heading", "banner", "main content", "contentInfo")
2. Allow to skip unimportant parts of the page ("heading", "banner") via a dedicated skip link, that's only visible on focus and clearly labeled with text.
3. Convert a single non-descriptive "Access + image" button into a) header "Sign in to Whole Tale" and a simple "Sing in with <provider>" button.
4. Add a GitHub as an additional OAuth provider
5. Make a login button selectable via keyboard and act on "enter" being pressed to follow the link. 

See comparison:
![aria_login](https://user-images.githubusercontent.com/352673/162791200-65c817c1-de7f-4f1a-99ee-c5f0a40119de.png)

## How to Test

Prerequisites: Set up GitHub client id/secret in girder.

1. Checkout this branch locally, rebuild the dashboard
2. Go to https://dashboard.local.wholetale.org
3. Press `<TAB>`:
    * Skip content link should pop up in the upper left corner. Note: it's gonna have an ugly color and it will overlap the logo, but it doesn't really matter for screen reader I think...
    * Press Enter. Page should reload to https://dashboard.local.wholetale.org/login#start-of-content
4. Press `<TAB>` once and press `<ENTER>`. You should begin the login oauth flow with GitHub.
