### PR TITLE
Run Tale > Metadata > Advanced > Tale Config section

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@ngrx/effects": "~12.2.0",
     "@ngrx/entity": "~12.2.0",
     "@ngrx/store": "~12.2.0",
+    "ajv": "^8.11.0",
     "compression": "~1.7.3",
     "core-js": "~3.3",
     "debug": "~4.1.1",

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -164,7 +164,7 @@ Fields Names / Order:
             <label class="transition visible">Tale Configuration</label>
             <textarea style="width:60%" [(ngModel)]="configModel" (ngModelChange)="configChanged()"></textarea>
           </div>
-          <span style="color:white;background:#d95c5c;" *ngIf="configError">ERROR: {{ configError }}</span>
+          <p style="color:#a94442;" *ngIf="configError">ERROR: {{ configError }}</p>
         </div>
 
 <!--

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -155,6 +155,18 @@ Fields Names / Order:
           </div>
         </div>
 
+        <div class="ui accordion field" style="margin-left:10vw">
+          <div class="title">
+            <i class="icon dropdown"></i>
+            Advanced
+          </div>
+          <div class="content field">
+            <label class="transition visible">Tale Configuration</label>
+            <textarea style="width:60%" [(ngModel)]="configModel" (ngModelChange)="configChanged()"></textarea>
+          </div>
+          <span style="color:white;background:#d95c5c;" *ngIf="configError">ERROR: {{ configError }}</span>
+        </div>
+
 <!--
         <div class="inline fields ui grid">
           <label class="two wide column right aligned">Published location</label>

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -192,12 +192,12 @@ export class TaleMetadataComponent implements OnInit, OnDestroy {
   }
 
   saveEdit(): void {
+    this.editing = false;
+
     // Update the Tale in Girder, then in Angular
     this.updateTale().then((res) => {
       // Overwrite our backup of the Tale's state in memory with a new one
       this.saveState();
-
-      this.editing = false;
       this.scrollToTop();
     });
   }

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ChangeDetectorRef, Component, Input, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ApiConfiguration } from '@api/api-configuration';
@@ -10,6 +11,7 @@ import { NotificationService } from '@shared/error-handler/services/notification
 import { Collaborator, CollaboratorList } from '@tales/components/rendered-tale-metadata/rendered-tale-metadata.component';
 import { TaleAuthor } from '@tales/models/tale-author';
 import { SyncService } from '@tales/sync.service';
+import Ajv, {ValidateFunction} from 'ajv';
 import { from, Observable, Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -47,8 +49,10 @@ export class TaleMetadataComponent implements OnInit, OnDestroy {
   configModel = '{}';
   configModelChanged = new Subject<string>();
   configError = '';
+  configValidator: ValidateFunction;
 
   updateSubscription: Subscription;
+  ajv = new Ajv();
 
   get canEdit(): boolean {
     if (!this.tale) {
@@ -68,6 +72,12 @@ export class TaleMetadataComponent implements OnInit, OnDestroy {
     try {
       const config = JSON.parse(this.configModel);
       this.configError = '';
+      const valid = this.configValidator(config);
+      if (!valid) {
+        this.configError = this.ajv.errorsText(this.configValidator.errors);
+
+        return false;
+      }
 
       return this._editState.config = config;
     } catch (e) {
@@ -106,6 +116,7 @@ export class TaleMetadataComponent implements OnInit, OnDestroy {
               private errorHandler: ErrorService,
               private imageService: ImageService,
               private syncService: SyncService,
+              private http: HttpClient,
               private dialog: MatDialog) {
     this.apiRoot = this.config.rootUrl;
     this.configModelChanged
@@ -121,6 +132,19 @@ export class TaleMetadataComponent implements OnInit, OnDestroy {
     const params = {};
     this.environments = this.imageService.imageListImages(params);
     this.licenses = this.licenseService.licenseGetLicenses();
+    const httpOptions = {
+      withCredentials: true,
+      responseType: 'text' as 'json',
+      headers: new HttpHeaders({'Content-Type': 'application/json'})
+    };
+
+    this.http.get(`${this.apiRoot}/describe`, httpOptions).subscribe((resp: string) => {
+      const schemas = JSON.parse(resp);
+      delete schemas.definitions.containerConfig.$schema;
+      this.configValidator = this.ajv.compile(schemas.definitions.containerConfig);
+    }, (err: any) => {
+      this.logger.error("Failed to fetch WT Schemas:", err);
+    });
     setTimeout(() => {
       $('#environmentDropdown:parent').dropdown().css('width', '100%');
       $('#licenseDropdown:parent').dropdown().css('width', '100%');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "sourceMap": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,6 +2808,16 @@ ajv@^8.0.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"


### PR DESCRIPTION
## Problem
There are several advanced features that cannot currently be edited / configured via the Metadata view in the UI

Fixes #271 

## Approach
Add an "Advanced" section the the Run Tale > Metadata view that allows the user to adjust the Tale configuration (`tale.config`). This includes very basic JSON validation that is not aware of required fields or the expected types within

See https://recordit.co/gFWiCmPSQD for demonstration

## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
4. Navigate to Run Tale > Metadata for a Tale the you own
    * You should see the read-only / rendered Metadata view
5. Click the Edit button at the bottom
    * You should see the editable Metadata view
6. Scroll all the way to the bottom of the form
    * You should see a new collapsed section marked "Advanced"
7. Click on "Advanced" to expand the new section
    * You should see a `textarea` appear labeled "Tale Configuration"
    * You should see that Tale Configuration defaults to an empty object: `{}`
8. Edit the Tale configuration value to an invalid JSON string: e.g. `{"this"."is":"not"valid}JSON`
    * You should see a (debounced) validation error appear after you stop typing
    * The error should indicate that the JSON entered is not valid
9. Click the Save button with invalid input still entered
    * You should see a notification / error popup appear after clicking Save
10. Refresh the page, click Edit, and expand the Advanced section again
    * You should see that the default value is still here, and the invalid value was not saved
11. Enter a valid JSON config instead and click Save again: e.g. `{"this":"is","totally":"nonsensical","but":"still","valid":"JSON"}`
    * You should see the red validation error disappears
    * You should see a notification popup saying that the "Tale saved successfully"
12. Refresh the page, click Edit again, and expand the Advanced section once more
    * You should see the value that you saved has been stored here