### PR TITLE
Add json schema validation for Tale Advanced Config section

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@ngrx/effects": "~12.2.0",
     "@ngrx/entity": "~12.2.0",
     "@ngrx/store": "~12.2.0",
+    "ajv": "^8.11.0",
     "compression": "~1.7.3",
     "core-js": "~3.3",
     "debug": "~4.1.1",

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.html
@@ -164,7 +164,7 @@ Fields Names / Order:
             <label class="transition visible">Tale Configuration</label>
             <textarea style="width:60%" [(ngModel)]="configModel" (ngModelChange)="configChanged()"></textarea>
           </div>
-          <span style="color:white;background:#d95c5c;" *ngIf="configError">ERROR: {{ configError }}</span>
+          <p style="color:#a94442;" *ngIf="configError">ERROR: {{ configError }}</p>
         </div>
 
 <!--

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.ts
@@ -49,7 +49,7 @@ export class TaleMetadataComponent implements OnInit, OnDestroy {
   configModel = '{}';
   configModelChanged = new Subject<string>();
   configError = '';
-  configValidator: ValidateFunction<any>;
+  configValidator: ValidateFunction;
 
   updateSubscription: Subscription;
   ajv = new Ajv();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "sourceMap": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,6 +2808,16 @@ ajv@^8.0.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"


### PR DESCRIPTION
## Problem

I won't lie: testing step 11. from https://github.com/whole-tale/ngx-dashboard/pull/274 made me sad. Not that anything is wrong with it, but I was really sad to learn that backend allows that. We're gonna fix it soon, but that's beside the point. We shouldn't allow user to put junk into their tales and I think that validating it before sending it to the server is the simplest approach.

## Approach
1. Fetch JSON schema from the backend whenever metadata editor is opened.
2. Using [ajv](https://ajv.js.org/) create a validator function using a proper schema.
3. Whenever advanced config string changes validate it and return error message.

## How to Test

1. Modify `wholetale` plugin locally by adding `"additionalProperties": False,` to `containerConfigSchema` in `server/schema/misc.py`.
2. Follow steps from  https://github.com/whole-tale/ngx-dashboard/pull/274
3. step 11 should now fail with a proper error message.
