### PR TITLE
Make "search" case insensitive and include category field

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
+++ b/src/app/+tale-catalog/tale-catalog/pipes/search-tales.pipe.ts
@@ -14,17 +14,22 @@ export class SearchTalesPipe implements PipeTransform {
       return value;
     }
 
+    searchQuery = searchQuery.toLowerCase()
+
     const filteredTales: Array<Tale> = [];
     value.forEach((tale: Tale) => {
       // Check title / description / creator first (should catch 99% of cases)
-      if (tale.title && tale.title.includes(searchQuery)) {
+      if (tale.title && tale.title.toLowerCase().includes(searchQuery)) {
         this.logger.info("Found in title: ", tale.title);
         filteredTales.push(tale);
-      } else if (tale.description && tale.description.includes(searchQuery)) {
+      } else if (tale.description && tale.description.toLowerCase().includes(searchQuery)) {
         this.logger.info("Found in description: ", tale.description);
         filteredTales.push(tale);
+      } else if (tale.category && tale.category.toLowerCase().includes(searchQuery)) {
+        this.logger.info("Found in category: ", tale.category);
+        filteredTales.push(tale);
       } else if (tale._id && creators && creators[tale._id] && creators[tale._id].name
-            && creators[tale._id].name.includes(searchQuery)) {
+            && creators[tale._id].name.toLowerCase().includes(searchQuery)) {
         this.logger.info("Found in creator name: ", creators[tale._id].name);
         filteredTales.push(tale);
       } else {
@@ -32,9 +37,9 @@ export class SearchTalesPipe implements PipeTransform {
 
         // Otherwise, check authors exhaustively
         if (tale.authors.some((author: TaleAuthor) => {
-          const firstNameContains = author.firstName && author.firstName.includes(searchQuery);
-          const lastNameContains = author.lastName && author.lastName.includes(searchQuery);
-          const orcidContains = author.orcid && author.orcid.includes(searchQuery);
+          const firstNameContains = author.firstName && author.firstName.toLowerCase().includes(searchQuery);
+          const lastNameContains = author.lastName && author.lastName.toLowerCase().includes(searchQuery);
+          const orcidContains = author.orcid && author.orcid.toLowerCase().includes(searchQuery);
           const result = firstNameContains || lastNameContains || orcidContains;
 
           return result;


### PR DESCRIPTION
## Problem
Searching for tales is currently case sensitive and doesn't include the category field. This fixes that.

## Approach
Update the `SearchTalesPipe` to match existing fields irrespective of case and add category as a searched field.

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Create two tales: 1) Title: ABC 123 Category: XYZ and 2) Title: abc 123 Category: efg
3. Search for "abc" both tales should result; search for "xyz" and the first tale should appear

### Note:
I was surprised to learn that we implemented a Javascript-based search instead of using the  GET `tales` endpoint's text search feature. But this should work for now.