### PR TITLE
feat: copyTale should copy specific Tale version

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -379,11 +379,10 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     }
 
     copyTale(): void {
-      this.taleService.taleCopyTale(this.tale._id, this.tale.restoredFrom).subscribe(res => {
-        this.logger.debug("Tale copying:", res);
+      this.taleService.taleCopyTale(this.tale._id).subscribe(res => {
+        this.logger.debug("Cloning entire Tale (including versions):", res);
       });
     }
-
 
     // Expected parameter format:
     //    dataMap: [{"name":"Elevation per SASAP region and Hydrolic Unit (HUC8) boundary for Alaskan watersheds","dataId":"resource_map_doi:10.5063/F1Z60M87","repository":"DataONE","doi":"10.5063/F1Z60M87","size":10293583}]

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -337,8 +337,9 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
 
     saveTaleVersion(): void {
       this.logger.debug('Saving Tale version');
-      this.versionService.versionCreateVersion({ taleId: this.taleId, force: true }).subscribe(version => {
+      this.versionService.versionCreateVersion({ taleId: this.taleId, force: true }).subscribe((version: Version) => {
         this.logger.debug("Version saved successfully:", version);
+        this.taleService.taleRestoreVersion(this.taleId, version._id);
       });
     }
 
@@ -378,7 +379,7 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     }
 
     copyTale(): void {
-      this.taleService.taleCopyTale(this.tale._id).subscribe(res => {
+      this.taleService.taleCopyTale(this.tale._id, this.tale.restoredFrom).subscribe(res => {
         this.logger.debug("Tale copying:", res);
       });
     }

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.html
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.html
@@ -72,7 +72,8 @@
         (elementRemoved)="removeElement($event)"
         (elementDownloaded)="downloadElement($event)"
         (elementCopied)="copyElement($event)"
-        (elementMoved)="moveElement($event)">
+        (elementMoved)="moveElement($event)"
+        (copyTaleVersionAsNewTale)="copyTaleVersionAsNewTale($event)">
       </app-file-explorer>
     </div>
   </div>

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -1016,4 +1016,12 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
     this.currentFolderId = element._id;
     this.navigate();
   }
+
+  copyTaleVersionAsNewTale(taleVersionId: string): void {
+    this.logger.debug("Cloning version into new Tale:", taleVersionId);
+    this.taleService.taleCopyTale(this.tale._id, taleVersionId, true).subscribe((res: Tale) => {
+      const newTaleId = res._id;
+      this.router.navigate(['run', newTaleId], { queryParams: { tab: 'metadata' } });
+    });
+  }
 }

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -1022,11 +1022,8 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
     this.taleService.taleCopyTale(this.tale._id, taleVersionId, true).subscribe((res: Tale) => {
       const newTaleId = res._id;
 
-      // Router redirect here does not fuly refresh the view
-      // this.router.navigate(['run', newTaleId], { queryParamsHandling: 'preserve' });
-
-      // Workaround: use window.location.href for this edged case for now
-      window.location.href =`${window.origin}/run/${newTaleId}?tab=files&nav=tale_versions`;
+      // Router redirect here does not fully refresh the view
+      this.router.navigate(['run', newTaleId], { queryParamsHandling: 'preserve' });
     });
   }
 }

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -1021,7 +1021,12 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
     this.logger.debug("Cloning version into new Tale:", taleVersionId);
     this.taleService.taleCopyTale(this.tale._id, taleVersionId, true).subscribe((res: Tale) => {
       const newTaleId = res._id;
-      this.router.navigate(['run', newTaleId], { queryParams: { tab: 'metadata' } });
+
+      // Router redirect here does not fuly refresh the view
+      // this.router.navigate(['run', newTaleId], { queryParamsHandling: 'preserve' });
+
+      // Workaround: use window.location.href for this edged case for now
+      window.location.href =`${window.origin}/run/${newTaleId}?tab=files&nav=tale_versions`;
     });
   }
 }

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -20,6 +20,8 @@
     <div class="ui message" style="height:100%;" *ngIf="!timeline.length">
       No previous versions saved for Tale.
     </div>
+
+    <!-- Dropdown for Versions/Runs -->
     <div class="item" *ngFor="let res of timeline; index as i; trackBy: trackById"
             [ngClass]="{ 'selected-version': tale.restoredFrom === res._id }">
         <div class="right floated content" *ngIf="!res.runVersionId">
@@ -37,11 +39,12 @@
                 <!-- Hide these options in the UI to make the Versions panel mostly read-only -->
                 <div class="item" (click)="renameVersion(res)" *ngIf="false && tale._accessLevel >= AccessLevel.Write">Rename</div>
                 <div class="item" (click)="deleteVersion(res)" *ngIf="false && tale._accessLevel >= AccessLevel.Admin">Delete</div>
+                <div class="item" *ngIf="!res.runVersionId" (click)="copyTaleVersionAsNewTale(res._id)">As New Tale</div>
+
               </div>
           </div>
         </div>
 
-        <!-- Dropdown for Runs -->
         <div class="right floated content" *ngIf="res.runVersionId">
           <div class="ui floating version dropdown icon" tabindex="0">
             <i class="fas fa-ellipsis-v"></i>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -1,6 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ChangeDetectorRef, Component, EventEmitter, Input, NgZone, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
 import { ApiConfiguration } from '@api/api-configuration';
 import { AccessLevel, Run, Tale, Version } from '@api/models';
 import { RunService, TaleService, VersionService } from '@api/services';
@@ -66,6 +67,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
               private runService: RunService,
               private dialog: MatDialog,
               private notificationService: NotificationService,
+              private router: Router,
               private syncService: SyncService) {
   }
 
@@ -311,6 +313,16 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
           });
         }
       });
+    });
+  }
+
+  copyTaleVersionAsNewTale(taleVersionId: string): void {
+    this.logger.debug("Cloning version into new Tale:", taleVersionId);
+    this.taleService.taleCopyTale(this.tale._id, taleVersionId, true).subscribe((res: Tale) => {
+      const newTaleId = res._id;
+
+      // Router redirect here does not fully refresh the view
+      this.router.navigate(['run', newTaleId], { queryParamsHandling: 'preserve' });
     });
   }
 }

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -1,12 +1,10 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ChangeDetectorRef, Component, EventEmitter, Input, NgZone, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
-import { NgForm } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { ApiConfiguration } from '@api/api-configuration';
 import { AccessLevel, Run, Tale, Version } from '@api/models';
 import { RunService, TaleService, VersionService } from '@api/services';
 import { TokenService } from '@api/token.service';
-import { ViewLogsDialogComponent } from '@layout/notification-stream/modals/view-logs-dialog/view-logs-dialog.component';
 import { LogService } from '@shared/core';
 import { ErrorModalComponent } from '@shared/error-handler/error-modal/error-modal.component';
 import { NotificationService } from '@shared/error-handler/services/notification.service';

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -70,7 +70,6 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   ngOnInit(): void {
-    this.refresh();
     this.versionsSubscription = this.syncService.taleUpdatedSubject.subscribe((taleId) => {
       if (taleId === this.tale._id) {
         this.refresh();
@@ -79,6 +78,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   ngOnChanges(): void {
+    this.refresh();
     setTimeout(() => {
       $('.ui.version.dropdown').dropdown({ context: 'body', keepOnScreen: true});
     }, 500);

--- a/src/app/api/services/tale.service.ts
+++ b/src/app/api/services/tale.service.ts
@@ -406,14 +406,16 @@ class TaleService extends __BaseService {
   }
 
   /**
-   * @param id The ID of the document.
+   @param id The ID of the Tale to copy.
+   @param versionId (optional) the ID of the Tale Version to copy. If set, only current version will be copied.
+   @param shallow If true, copy only current state. If versionId is set, copy only current Version.
    */
-  taleCopyTaleResponse(id: string, versionId?: string): __Observable<__StrictHttpResponse<null>> {
+  taleCopyTaleResponse(id: string, versionId?: string, shallow = false): __Observable<__StrictHttpResponse<null>> {
     let __params = this.newParams();
     let __headers = new HttpHeaders();
     let __body: any = null;
 
-    const url = this.rootUrl + versionId ? `/tale/${id}/copy?versionId=${versionId}` : `/tale/${id}/copy`;
+    const url = this.rootUrl + (versionId ? `/tale/${id}/copy?versionId=${versionId}&shallow=${shallow}` : `/tale/${id}/copy`);
     let req = new HttpRequest<any>('POST', url, __body, {
       headers: __headers,
       params: __params,
@@ -428,10 +430,12 @@ class TaleService extends __BaseService {
     );
   }
   /**
-   * @param id The ID of the document.
+   * @param id The ID of the Tale to copy.
+   * @param versionId (optional) the ID of the Tale Version to copy. If set, only current version will be copied.
+   * @param shallow If true, copy only current state. If versionId is set, copy only current Version.
    */
-  taleCopyTale(id: string, versionId?: string): __Observable<null> {
-    return this.taleCopyTaleResponse(id, versionId).pipe(__map((_r) => _r.body as null));
+  taleCopyTale(id: string, versionId?: string, shallow = false): __Observable<null> {
+    return this.taleCopyTaleResponse(id, versionId, shallow).pipe(__map((_r) => _r.body as null));
   }
 
   /**

--- a/src/app/api/services/tale.service.ts
+++ b/src/app/api/services/tale.service.ts
@@ -408,12 +408,13 @@ class TaleService extends __BaseService {
   /**
    * @param id The ID of the document.
    */
-  taleCopyTaleResponse(id: string): __Observable<__StrictHttpResponse<null>> {
+  taleCopyTaleResponse(id: string, versionId?: string): __Observable<__StrictHttpResponse<null>> {
     let __params = this.newParams();
     let __headers = new HttpHeaders();
     let __body: any = null;
 
-    let req = new HttpRequest<any>('POST', this.rootUrl + `/tale/${id}/copy`, __body, {
+    const url = this.rootUrl + versionId ? `/tale/${id}/copy?versionId=${versionId}` : `/tale/${id}/copy`;
+    let req = new HttpRequest<any>('POST', url, __body, {
       headers: __headers,
       params: __params,
       responseType: 'json',
@@ -429,8 +430,8 @@ class TaleService extends __BaseService {
   /**
    * @param id The ID of the document.
    */
-  taleCopyTale(id: string): __Observable<null> {
-    return this.taleCopyTaleResponse(id).pipe(__map((_r) => _r.body as null));
+  taleCopyTale(id: string, versionId?: string): __Observable<null> {
+    return this.taleCopyTaleResponse(id, versionId).pipe(__map((_r) => _r.body as null));
   }
 
   /**

--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -94,6 +94,7 @@
               <div class="item" (click)="downloadElement(ele)"><i class="fas fa-fw fa-download"></i> Download</div>
               <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions'))" class="item" (click)="openMoveToDialog(ele)"><i class="fas fa-fw fa-exchange-alt"></i> Move To...</div>
               <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions'))" class="item" (click)="copyElement(ele)"><i class="fas fa-fw fa-clone"></i> Copy</div>
+              <div *ngIf="currentNav === 'tale_versions'" class="item" (click)="copyTaleVersion(ele._id)"><i class="fas fa-fw fa-clone"></i> As New Tale</div>
             </div>
           </div>
         </td>

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -119,6 +119,7 @@ export class FileExplorerComponent implements OnChanges {
   @Output() readonly elementMoved = new EventEmitter<{ element: FileElement; moveTo?: FileElement }>();
   @Output() readonly navigatedDown = new EventEmitter<FileElement>();
   @Output() readonly navigatedUp = new EventEmitter();
+  @Output() readonly copyTaleVersionAsNewTale = new EventEmitter();
 
   showMore: any = {};
 
@@ -286,5 +287,9 @@ export class FileExplorerComponent implements OnChanges {
 
   openTaleWorkspacesDialog(event: any): void {
     this.openTaleWorkspacesModal.emit(event);
+  }
+
+  copyTaleVersion(taleVersionId: string): void {
+    this.copyTaleVersionAsNewTale.emit(taleVersionId);
   }
 }


### PR DESCRIPTION
## Problem
~~`copyTale` should copy the specific version that the user is viewing~~
The UI should offer a way to clone a specific Tale version as a new Tale, without including all other/previous version info.

Fixes #267

## Approach
* ~~Send `versionId` along with the API request to `/tale/:id/copy`~~
* Add a new dropdown item for Tale Versions: "As New Tale"


## How to Test
Prerequisites: at least one Tale created, at least two versions created

1. Checkout and run this branch locally, rebuild the dashboard
2. Log into the WholeTale Dashboard
3. Create a Tale (if you haven't already)
4. On the Tale, create two distinct versions (if you haven't already)
5. Navigate to Run > Files > Tale Versions for the Tale
    * You should see your 2 versions listed here
6. Expand the dropdown beside one of the Versions and choose "As New Tale"
    * You should be redirected to the Run > Files view for your newly-created Tale copy
    * You should no longer see the other versions listed here (beside the one that was selected for "As New Tale" originally)