### PR TITLE
Create Tale from DOI

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
@@ -1,41 +1,58 @@
-<h1 mat-dialog-title>Create New Tale</h1>
+<h1 mat-dialog-title *ngIf="!isTale && (mode === 'doi')">Create New Tale from DOI</h1>
+<h1 mat-dialog-title *ngIf="!isTale && (mode === 'git')">Create New Tale from Git repository</h1>
+<h1 mat-dialog-title *ngIf="isTale">Import Tale</h1>
 
 <mat-dialog-content>
   <form class="ui form segment">
-    <div class="field" *ngIf="showGit">
-      <label>Git repository URL</label>
-      <input matInput type="text" name="repo" placeholder="Enter a repository URL" [(ngModel)]="gitUrl" required />
+    <div class="ui active inverted dimmer" *ngIf="loading">
+      <div class="ui text loader"></div>
     </div>
 
-    <div class="field">
-      <label>Title</label>
-      <input matInput type="text" name="title" placeholder="Enter a Tale Name" [(ngModel)]="newTale.title" required />
+    <div class="ui message" *ngIf="error">
+      <div class="ui text">Failed to find DOI/URL</div>
     </div>
 
-    <div class="field">
-      <label>Compute Environment</label>
-      <select class="ui dropdown" name="imageId" [(ngModel)]="newTale.imageId" required>
-        <option value="">Choose a Compute Environment...</option>
-        <option class="item" [ngValue]="env._id" *ngFor="let env of environments; index as i; trackBy: trackById">
-          <img class="ui avatar image" [src]="env.icon" />
-          {{ env.name }}
-        </option>
-      </select>
-    </div>
+    <div *ngIf="!(mode === 'ainwt') || ( (mode === 'ainwt') && found)">
+      <div class="field" *ngIf="mode === 'git'">
+        <label>Git repository URL</label>
+        <input matInput type="text" name="repo" placeholder="Enter a repository URL" [(ngModel)]="gitUrl" required />
+      </div>
 
-    <div class="field" *ngIf="!datasetCitation">
-        <label>Input Data</label>
-        <p>Add data after Tale creation using your chosen compute environment, or the Files tab of your running Tale.</p>
-        <!-- <input type="hidden" name="dataSet" [(ngModel)]="newTale.dataSet" /> -->
-    </div>
-    <div class="field" *ngIf="datasetCitation">
-        <label>Input Data</label>
-        <small>Data Source: {{ datasetCitation.doi }}</small>
-        <!-- <input type="hidden" name="dataSet" [(ngModel)]="newTale.dataSet" /> -->
-    </div>
+      <div class="field" *ngIf="mode === 'doi'">
+        <label>DOI or dataset URL</label>
+        <input matInput type="text" name="repo" placeholder="Enter a DOI or dataset URL" [(ngModel)]="doiUrl" required (change)="lookupDOI($event)"/>
+      </div>
 
-    <div class="field" *ngIf="datasetCitation">
-        <div class="ui radio checkbox">
+      <div class="field">
+        <label>Title</label>
+        <input matInput type="text" name="title" placeholder="Enter a Tale Name" [(ngModel)]="newTale.title" required />
+      </div>
+  
+      <div class="field" *ngIf="!isTale">
+        <label>Compute Environment</label>
+        <select class="ui dropdown" name="imageId" [(ngModel)]="newTale.imageId" required>
+          <option value="">Choose a Compute Environment...</option>
+          <option class="item" [ngValue]="env._id" *ngFor="let env of environments; index as i; trackBy: trackById">
+            <img class="ui avatar image" [src]="env.icon" />
+            {{ env.name }}
+          </option>
+        </select>
+      </div>
+  
+      <div *ngIf="!isTale">
+        <div class="field" *ngIf="!datasetCitation && !(mode === 'doi')">
+          <label>Input Data</label>
+          <p>Add data after Tale creation using your chosen compute environment, or the Files tab of your running Tale.</p>
+          <!-- <input type="hidden" name="dataSet" [(ngModel)]="newTale.dataSet" /> -->
+        </div>
+        <div class="field" *ngIf="datasetCitation">
+          <label>Input Data</label>
+          <small>Data Source: {{ datasetCitation.doi }}</small>
+          <!-- <input type="hidden" name="dataSet" [(ngModel)]="newTale.dataSet" /> -->
+        </div>
+
+        <div class="field" *ngIf="datasetCitation">
+          <div class="ui radio checkbox">
             <input id="readOnlyRadio" type="radio" name="access" checked="" (change)="enableReadOnly($event)" tabindex="0" class="hidden">
             <label>
                 <b>READ ONLY</b>
@@ -43,13 +60,15 @@
                 <a [href]="docUrl"
                    style="margin-left: .75rem;font-style:italic" target="_blank">Why would I do this?</a>
             </label>
+          </div>
         </div>
-    </div>
-    <div class="field"  *ngIf="datasetCitation">
-        <div class="ui radio checkbox">
+        <div class="field" *ngIf="datasetCitation">
+          <div class="ui radio checkbox">
             <input id="readWriteRadio" type="radio" name="access" (change)="enableReadWrite($event)" tabindex="0" class="hidden">
             <label><b>READ/WRITE</b> — Enable data editing</label>
+          </div>
         </div>
+      </div>
     </div>
 
     <!--<button class="ui button" type="submit">Submit</button>-->
@@ -58,7 +77,7 @@
 
 <mat-dialog-actions>
   <button class="ui black deny button" mat-dialog-close>Cancel</button>
-  <button class="ui positive right labeled icon button" [disabled]="!newTale.title || !newTale.imageId || (data.showGit && !gitUrl)" [mat-dialog-close]="result()">
+  <button class="ui positive right labeled icon button" [disabled]="!newTale.title || (!isTale && !newTale.imageId) || ((data.mode === 'git') && !gitUrl)" [mat-dialog-close]="result()">
     Create New Tale
     <i class="play icon"></i>
   </button>

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
@@ -1,6 +1,4 @@
-<h1 mat-dialog-title *ngIf="!isTale && (mode === 'doi')">Create New Tale from DOI</h1>
-<h1 mat-dialog-title *ngIf="!isTale && (mode === 'git')">Create New Tale from Git repository</h1>
-<h1 mat-dialog-title *ngIf="isTale">Import Tale</h1>
+<h1 mat-dialog-title>{{title}}</h1>
 
 <mat-dialog-content>
   <form class="ui form segment">
@@ -12,7 +10,7 @@
       <div class="ui text">Failed to find DOI/URL</div>
     </div>
 
-    <div [hidden]="mode !== 'ainwt' || !found">
+    <div *ngIf="!(mode === 'ainwt') || ( (mode === 'ainwt') && found)">
       <div class="field" *ngIf="mode === 'git'">
         <label>Git repository URL</label>
         <input matInput type="text" name="repo" placeholder="Enter a repository URL" [(ngModel)]="gitUrl" required />
@@ -53,7 +51,7 @@
 
         <div class="field" [hidden]="!datasetCitation">
           <div class="ui radio checkbox">
-            <input id="readOnlyRadio" type="radio" name="access" checked="" (change)="enableReadOnly($event)" tabindex="0" class="hidden">
+            <input type="radio" name="asTale" checked="" [(ngModel)]="asTale" [value]="false" />
             <label>
                 <b>READ ONLY</b>
                 <i style="margin-left:5px;">recommended</i> — Treat as source dataset for analysis
@@ -64,7 +62,7 @@
         </div>
         <div class="field" [hidden]="!datasetCitation">
           <div class="ui radio checkbox">
-            <input id="readWriteRadio" type="radio" name="access" (change)="enableReadWrite($event)" tabindex="0" class="hidden">
+            <input type="radio" name="asTale" checked="" [(ngModel)]="asTale" [value]="true" />
             <label><b>READ/WRITE</b> — Enable data editing</label>
           </div>
         </div>

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>{{title}}</h1>
+<h1 mat-dialog-title>{{ title }}</h1>
 
 <mat-dialog-content>
   <form class="ui form segment">

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.html
@@ -12,7 +12,7 @@
       <div class="ui text">Failed to find DOI/URL</div>
     </div>
 
-    <div *ngIf="!(mode === 'ainwt') || ( (mode === 'ainwt') && found)">
+    <div [hidden]="mode !== 'ainwt' || !found">
       <div class="field" *ngIf="mode === 'git'">
         <label>Git repository URL</label>
         <input matInput type="text" name="repo" placeholder="Enter a repository URL" [(ngModel)]="gitUrl" required />
@@ -27,7 +27,7 @@
         <label>Title</label>
         <input matInput type="text" name="title" placeholder="Enter a Tale Name" [(ngModel)]="newTale.title" required />
       </div>
-  
+
       <div class="field" *ngIf="!isTale">
         <label>Compute Environment</label>
         <select class="ui dropdown" name="imageId" [(ngModel)]="newTale.imageId" required>
@@ -38,7 +38,7 @@
           </option>
         </select>
       </div>
-  
+
       <div *ngIf="!isTale">
         <div class="field" *ngIf="!datasetCitation && !(mode === 'doi')">
           <label>Input Data</label>
@@ -51,7 +51,7 @@
           <!-- <input type="hidden" name="dataSet" [(ngModel)]="newTale.dataSet" /> -->
         </div>
 
-        <div class="field" *ngIf="datasetCitation">
+        <div class="field" [hidden]="!datasetCitation">
           <div class="ui radio checkbox">
             <input id="readOnlyRadio" type="radio" name="access" checked="" (change)="enableReadOnly($event)" tabindex="0" class="hidden">
             <label>
@@ -62,7 +62,7 @@
             </label>
           </div>
         </div>
-        <div class="field" *ngIf="datasetCitation">
+        <div class="field" [hidden]="!datasetCitation">
           <div class="ui radio checkbox">
             <input id="readWriteRadio" type="radio" name="access" (change)="enableReadWrite($event)" tabindex="0" class="hidden">
             <label><b>READ/WRITE</b> — Enable data editing</label>

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -57,10 +57,9 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
       copyOfTale: undefined,
       description: '### Provide a description for your Tale'
     };
-    console.log(data.mode);
     this.mode = data.mode as Mode;
-    console.log(this.mode);
     this.baseUrl = (data && data.params && data.params.api) ? decodeURIComponent(data.params.api) : '';
+
   }
 
   ngOnInit(): void {
@@ -72,7 +71,6 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
   }
 
   lookupDOI(evt: any): void {
-    console.log(evt);
     const doiUrl = evt.target.value;
     const dataId = [ doiUrl ];
     const params = { dataId: JSON.stringify(dataId), baseUrl: this.dataONERepositoryBaseUrl() }
@@ -124,6 +122,8 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
         this.datasetCitation = { doi: decodeURIComponent(this.data.params.uri) };
       });
 
+      this.asTale = this.data.params.asTale == "true";
+
       // Lookup dataset information
       const dataId = [this.data.params.uri];
       const params = { dataId: JSON.stringify(dataId), baseUrl: this.dataONERepositoryBaseUrl() }
@@ -145,13 +145,8 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
         this.error = true;
       });
 
-      // Set read/write radio buttons using asTale value
-      if (this.data.params.asTale) {
-        setTimeout(() => {
-          $('#readWriteRadio').click();
-        }, 350);
-      }
     }
+
 
     // Fetch all Tale environment Images
     const listImagesParams = { limit: 0 };
@@ -176,27 +171,28 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
     });
   }
 
-  enableReadOnly(evt: any): void {
-    console.log("Enabling read only on this Tale...");
-    const target = evt.target;
-    if (target.checked) {
-      this.asTale = false;
-    }
-  }
-
-  enableReadWrite(evt: any): void {
-    console.log("Enabling read/write on this Tale...");
-    const target = evt.target;
-    if (target.checked) {
-      this.asTale = true;
-    }
-  }
-
   trackById(index: number, env: Image): string {
     return env._id;
   }
 
   get docUrl(): string {
     return `${window.env.rtdBaseUrl}/users_guide/compose.html`;
+  }
+
+  get title(): string {
+    let title = 'Create New Tale';
+    if (this.isTale) {
+      title = 'Import Tale';
+    } else {
+      switch(this.mode) {
+        case Mode.Git:
+          title = title + ' from Git';
+          break;
+        case Mode.DOI:
+          title = title + ' from DOI';
+          break;
+      }
+    }
+    return title;
   }
 }

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -1,9 +1,8 @@
 import { AfterViewInit, Component, Inject, NgZone, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Image, Tale } from '@api/models';
-import { ImageService } from '@api/services';
+import { ImageService, RepositoryService } from '@api/services';
 import { LogService } from '@shared/core';
-import { RepositoryService } from '@api/services';
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -13,7 +12,7 @@ enum Mode {
   Git = "git",
   DOI = "doi",
   AinWT = "ainwt",
-};
+}
 
 @Component({
   templateUrl: './create-tale-modal.component.html',
@@ -194,13 +193,17 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
     } else {
       switch(this.mode) {
         case Mode.Git:
-          title = title + ' from Git';
+          title = `${title} from Git`;
           break;
         case Mode.DOI:
-          title = title + ' from DOI';
+          title = `${title} from DOI`;
+          break;
+        case Mode.Default:
+        default:
           break;
       }
     }
+
     return title;
   }
 }

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -89,8 +89,8 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
       }
     }, err => {
       this.logger.error(`Failed to find DOI/URL=${doiUrl}:`, err);
-      this.loading = false;
       this.error = true;
+      this.reset();
     });
   }
 
@@ -141,8 +141,8 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
         }
       }, err => {
         this.logger.error(`Failed to find DOI/URL=${this.data.params.uri}:`, err);
-        this.loading = false;
         this.error = true;
+        this.reset();
       });
 
     }
@@ -173,6 +173,15 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
 
   trackById(index: number, env: Image): string {
     return env._id;
+  }
+
+  reset(): void {
+    this.newTale.title = '';
+    this.newTale.imageId = '';
+    this.loading = false;
+    this.datasetCitation = {};
+    this.isTale = false;
+    this.asTale = false;
   }
 
   get docUrl(): string {

--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -19,7 +19,7 @@ enum Mode {
   templateUrl: './create-tale-modal.component.html',
   styleUrls: ['./create-tale-modal.component.scss']
 })
-export class CreateTaleModalComponent implements OnInit,AfterViewInit {
+export class CreateTaleModalComponent implements OnInit, AfterViewInit {
   newTale: Tale;
   datasetCitation: any;
   asTale = false;
@@ -58,7 +58,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       description: '### Provide a description for your Tale'
     };
     console.log(data.mode);
-    this.mode = <Mode>data.mode;
+    this.mode = data.mode as Mode;
     console.log(this.mode);
     this.baseUrl = (data && data.params && data.params.api) ? decodeURIComponent(data.params.api) : '';
   }
@@ -73,7 +73,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
 
   lookupDOI(evt: any): void {
     console.log(evt);
-    var doiUrl = evt.target.value;
+    const doiUrl = evt.target.value;
     const dataId = [ doiUrl ];
     const params = { dataId: JSON.stringify(dataId), baseUrl: this.dataONERepositoryBaseUrl() }
     this.isTale = false;
@@ -100,7 +100,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
   result(): { tale: Tale, asTale: boolean, url?: string, baseUrl?: string } {
     if (this.data.mode === Mode.Git) {
       return { tale: this.newTale, asTale: this.asTale, baseUrl: this.baseUrl, url: this.gitUrl };
-    } else if (this.data.mode == Mode.DOI) {
+    } else if (this.data.mode === Mode.DOI) {
       return { tale: this.newTale, asTale: this.asTale, baseUrl: this.baseUrl, url: this.doiUrl };
     } else {
       return { tale: this.newTale, asTale: this.asTale, baseUrl: this.baseUrl };
@@ -133,7 +133,7 @@ export class CreateTaleModalComponent implements OnInit,AfterViewInit {
       this.repositoryService.repositoryLookupData(params).subscribe((values: Array<any>) => {
         if (values.length > 0) {
           setTimeout(() => {
-	    this.isTale = values[0].tale;
+            this.isTale = values[0].tale;
             this.newTale.title = values[0].name;
             this.loading = false;
             this.found = true;

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.html
@@ -20,8 +20,9 @@
                             <i class="plus icon"></i>
                             Create New Tale
                             <div class="menu transition hidden" tabindex="-1">
-                                <a class="item" (click)="openCreateTaleModal(false)">Create New Tale</a>
-                                <a class="item" (click)="openCreateTaleModal(true)">Create Tale from Git Repository</a>
+                                <a class="item" (click)="openCreateTaleModal('default')">Create New Tale</a>
+                                <a class="item" (click)="openCreateTaleModal('git')">Create Tale from Git Repository</a>
+                                <a class="item" (click)="openCreateTaleModal('doi')">Create Tale from DOI</a>
                             </div>
                         </button>
 						</div>

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -86,11 +86,13 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
 
     openCreateTaleModal(mode: string): void {
       const config: MatDialogConfig = {
+        width: '600px',
         data: { mode }
       };
       const dialogRef = this.dialog.open(CreateTaleModalComponent, config);
       dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url?: string, baseUrl: string}) => {
         const tale = result.tale;
+        const asTale = result.asTale;
         const gitOrDoiUrl = result.url;
         const baseUrl = result.baseUrl;
 
@@ -98,43 +100,25 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
 
         // TODO: Validation
 
-        if (mode === "git") {
+        if (mode === "git" || mode === "doi") {
+   
           // Import Tale from Git repo
           const params = {
             url: gitOrDoiUrl ? gitOrDoiUrl: '', // Pull from querystring/form
             imageId: tale.imageId, // Pull from user input
-            asTale: false, // Pull from user input
-            git: true,
+            asTale: asTale, 
+            git: mode === "git",
             spawn: false, // if true, immediately launch a Tale instance
             taleKwargs: tale.title ? { title: tale.title } : {},
             lookupKwargs: baseUrl ? { base_url: baseUrl } : {},
           };
 
           this.taleService.taleCreateTaleFromUrl(params).subscribe((response: Tale) => {
-            this.logger.debug("Importing Tale from Git:", response);
+            this.logger.debug("Importing Tale:", response);
             this.taleCreated.emit(response);
             this.router.navigate(['run', response._id]);
           }, err => {
-            this.logger.error("Failed to create Tale from Git repo:", err);
-          });
-	}  else if (mode === "doi") {
-          // Import Tale from DOI
-          const params = {
-            url: gitOrDoiUrl ? gitOrDoiUrl: '', // Pull from querystring/form
-            imageId: tale.imageId, // Pull from user input
-            asTale: false, // Pull from user input
-            git: false,
-            spawn: false, // if true, immediately launch a Tale instance
-            taleKwargs: tale.title ? { title: tale.title } : {},
-            lookupKwargs: baseUrl ? { base_url: baseUrl } : {},
-          };
-
-          this.taleService.taleCreateTaleFromUrl(params).subscribe((response: Tale) => {
-            this.logger.debug("Importing Tale from DOI:", response);
-            this.taleCreated.emit(response);
-            this.router.navigate(['run', response._id]);
-          }, err => {
-            this.logger.error("Failed to create Tale from DOI:", err);
+            this.logger.error("Failed to create Tale:", err);
           });
         } else {
           // Create classic Tale

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -84,27 +84,27 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
       }, 1000);
     }
 
-    openCreateTaleModal(showGit = false): void {
+    openCreateTaleModal(mode: string): void {
       const config: MatDialogConfig = {
-        data: { showGit }
+        data: { mode }
       };
       const dialogRef = this.dialog.open(CreateTaleModalComponent, config);
       dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url?: string, baseUrl: string}) => {
         const tale = result.tale;
-        const gitUrl = result.url;
+        const gitOrDoiUrl = result.url;
         const baseUrl = result.baseUrl;
 
         if (!tale) { return; }
 
         // TODO: Validation
 
-        if (showGit) {
+        if (mode === "git") {
           // Import Tale from Git repo
           const params = {
-            url: gitUrl ? gitUrl: '', // Pull from querystring/form
+            url: gitOrDoiUrl ? gitOrDoiUrl: '', // Pull from querystring/form
             imageId: tale.imageId, // Pull from user input
             asTale: false, // Pull from user input
-            git: gitUrl ? true : false,
+            git: true,
             spawn: false, // if true, immediately launch a Tale instance
             taleKwargs: tale.title ? { title: tale.title } : {},
             lookupKwargs: baseUrl ? { base_url: baseUrl } : {},
@@ -116,6 +116,25 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
             this.router.navigate(['run', response._id]);
           }, err => {
             this.logger.error("Failed to create Tale from Git repo:", err);
+          });
+	}  else if (mode === "doi") {
+          // Import Tale from DOI
+          const params = {
+            url: gitOrDoiUrl ? gitOrDoiUrl: '', // Pull from querystring/form
+            imageId: tale.imageId, // Pull from user input
+            asTale: false, // Pull from user input
+            git: false,
+            spawn: false, // if true, immediately launch a Tale instance
+            taleKwargs: tale.title ? { title: tale.title } : {},
+            lookupKwargs: baseUrl ? { base_url: baseUrl } : {},
+          };
+
+          this.taleService.taleCreateTaleFromUrl(params).subscribe((response: Tale) => {
+            this.logger.debug("Importing Tale from DOI:", response);
+            this.taleCreated.emit(response);
+            this.router.navigate(['run', response._id]);
+          }, err => {
+            this.logger.error("Failed to create Tale from DOI:", err);
           });
         } else {
           // Create classic Tale


### PR DESCRIPTION
## Problem

* Creating or importing a tale based on a DOI or dataset URL currently relies on AinWT integration, knowledge of how to construct an AinWT URL, or use of an external tool (e.g., [rtd/ainwt](https://wholetale.readthedocs.io/en/latest/ainwt.html), [bookmarklet](https://wholetale.readthedocs.io/en/latest/users_guide/integration.html#bookmarklet-for-analyze-in-whole-tale)). 
* Using the `/mine?uri=` approach during AinWT is not dataset-aware (i.e., does not perform lookup) and also not Tale-aware (which is important because tales cannot be mounted read-only and must be imported).

## Approach
* Add "Create New Tale from DOI" to the "Create New Tale" menu and flow. This includes calling `lookup` to populate title and determine whether dataset is a tale.
* Handle both create and AinWT cases

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create New Tale from DOI 
   1. Enter DOI doi:10.7910/DVN/TJCLKP: Title should populate with the DVN dataset title
   2. Enter URL https://sandbox.zenodo.org/record/1059441: Modal should convert to import tale
   3. Enter a non-existent DOI, confirm that `Failed to find DOI/URL` message displays
   4. Confirm that radio buttons work as expected
5. Create tale using AinWT
   1. https://dashboard.local.wholetale.org/mine?uri=doi%3A10.7910%2FDVN%2FTJCLKP&asTale=true
   2. https://dashboard.local.wholetale.org/mine?uri=doi%3A10.7910%2FDVN%2FTJCLKP&asTale=false
   3. https://dashboard.local.wholetale.org/mine?uri=doi%3A10.7910%2FDVN%2FTJCLKP (defaults to `asTale=false`)
   4. https://dashboard.local.wholetale.org/mine?uri=https%3A%2F%2Fsandbox.zenodo.org%2Frecord%2F1059441  
6. Optionally, confirm that original create tale and Create from Git work. 


**Known issues:**
*  Zenodo tale import fails due to https://github.com/whole-tale/ngx-dashboard/pull/281