### PR TITLE
Public access to catalog (suggestions)

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -37,7 +37,7 @@
                                 <div class="six wide column" style="text-align: right;">
                                     <app-tale-run-button class="tale-run-button" *ngIf="tokenService?.user?.value" [tale]="tale" [instance]="instance" isPrimary="true" (taleInstanceStateChanged)="taleInstanceStateChanged($event)"></app-tale-run-button>
                                     <span title="You must log in to run this Tale." *ngIf="!tokenService?.user?.value">
-                                        <button class="ui disabled primary button">
+					    <button class="ui disabled primary button" matTooltip="You must log in to run this tale">
                                             <i class="play icon"></i>
                                             Run Tale
                                         </button>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -16,7 +16,7 @@
 
   <h3>Tale History</h3>
 
-  <div id="timeline" class="ui middle aligned divided list">
+  <div id="timeline" class="ui middle aligned divided list" style="height:100%;">
     <div class="ui message" style="height:100%;" *ngIf="!timeline.length">
       No previous versions saved for Tale.
     </div>
@@ -28,8 +28,8 @@
               <div class="menu left transition hidden silent" tabindex="-1" style="display: block !important;">
                 <div class="item" (click)="viewVersionInfo(res)">View Info</div>
 
-                <div class="item" (click)="restoreVersion(res)" *ngIf="tale._accessLevel >= AccessLevel.Write">Restore</div>
-                <div class="item" (click)="exportVersion(res)" *ngIf="tale._accessLevel >= AccessLevel.Read">Export</div>
+                <div class="item" (click)="restoreVersion(res)" *ngIf="tale._accessLevel >= AccessLevel.Write && tokenService?.user?.value">Restore</div>
+                <div class="item" (click)="exportVersion(res)" *ngIf="tale._accessLevel >= AccessLevel.Read && tokenService?.user?.value">Export</div>
 
                 <!-- TODO: Compare Versions button -->
                 <div class="item" *ngIf="false">Compare</div>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.ts
@@ -63,7 +63,7 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
               private zone: NgZone,
               private logger: LogService,
               private taleService: TaleService,
-              private tokenService: TokenService,
+              public tokenService: TokenService,
               private versionService: VersionService,
               private runService: RunService,
               private dialog: MatDialog,
@@ -91,15 +91,12 @@ export class TaleVersionsPanelComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   refresh(): void {
-    if (this.tokenService.user.value) {
-      this.versionService.versionListVersions({ taleId: this.tale._id }).subscribe((versions: Array<Version>) => {
-        this.runService.runListRuns({ taleId: this.tale._id }).subscribe((runs: Array<Run>) => {
-          this.timeline = versions.concat(runs).sort(this.sortByCreatedDate);
-          this.ref.detectChanges();
-        });
+    this.versionService.versionListVersions({ taleId: this.tale._id }).subscribe((versions: Array<Version>) => {
+      this.runService.runListRuns({ taleId: this.tale._id }).subscribe((runs: Array<Run>) => {
+        this.timeline = versions.concat(runs).sort(this.sortByCreatedDate);
+        this.ref.detectChanges();
       });
-    }
-
+    });
   }
 
   /**


### PR DESCRIPTION
I was tinkering and maybe these fix some of the issues I reported in https://github.com/whole-tale/ngx-dashboard/pull/277:
* Add a tooltip to the run button to indicate that the user needs to sign in?
* With https://github.com/whole-tale/wt_versioning/pull/45, allow non-logged-in user to view versions/runs but not see export or restore menu.