### PR TITLE
fix: prevent user from clicking Add multiple times in Run > Share

### DIFF
--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.html
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.html
@@ -57,7 +57,7 @@
                 <div class="item" data-value="2">Owns</div>
               </div>
            </div>
-           <button class="ui button primary" [disabled]="!newCollabUser" (click)="addCollaborator()">Add</button>
+           <button class="ui button primary" [disabled]="saving || !newCollabUser" (click)="addCollaborator()">Add</button>
          </div>
 
          <!-- Collaborator List -->

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.ts
@@ -49,6 +49,8 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
   newCollabAccess = 0;
   newCollabUser: User;
 
+  saving = false;
+
   handleChange(evt: any, level: string): void {
     const target = evt.target;
     if (!target.checked) {
@@ -306,6 +308,11 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
   }
 
   saveCollaborators(): Promise<any> {
+    if (this.saving) {
+      return;
+    }
+    this.saving = true;
+
     // Make sure Owner retains access (backend should validate this too)
     const owner = this.collaborators.users.find(user => this.tale.creatorId === user.id);
     if (!owner) {
@@ -331,6 +338,8 @@ export class TaleSharingComponent extends BaseComponent implements OnInit, OnCha
       this.logger.debug('Tale access updated successfully:', response);
       this.collaboratorsChange.emit(this.collaborators);
       this.refilterSearch(this.filterUsers(this.users));
+    }).finally(() => {
+      this.saving = false;
     });
 
     return promise;


### PR DESCRIPTION
## Problem
On the Run > Share view, if the user clicks Add multiple times in succession then they can end up with duplicate entires in the access list.

Fixes #266 

## Approach
Disable the "Add" button until we are finished processing the current request.

## How to Test
Prerequisites: at least one Tale that you own

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run > Share for a Tale that you own
4. Search for a user (e.g. `John Doe`)
5. Quickly attempt to press Add multiple times
    * You should be unable to click Add multiple times, as it should disable while processing the current request
