### PR TITLE
fix: notifications should appear without refresh, fix login/logout edge cases for private Tale

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -72,6 +72,10 @@
                 }
               ]
             },
+            "dev": {
+              "optimization": false,
+              "sourceMap": true
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -100,6 +104,9 @@
             "hmr": {
               "hmr": true,
               "browserTarget": "universal:build:hmr"
+            },
+            "dev": {
+              "browserTarget": "universal:build:dev"
             },
             "production": {
               "browserTarget": "universal:build:production"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "ng": "ng",
     "clean": "rimraf .cache dist coverage test-report.xml",
-    "start": "ng serve",
+    "start": "ng serve --configuration=dev",
     "start:prod": "ng serve --configuration production",
     "build": "ng build",
     "build:prod": "ng build --configuration production",

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -171,13 +171,6 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.logger.debug(`Fetching tale with _id=${this.taleId}`);
       this.taleService.taleGetTale(this.taleId)
                       .subscribe((tale: Tale) => {
-        if (!tale) {
-          this.logger.error("Tale is null, something went horribly wrong");
-          this.router.navigate(['public']);
-
-          return;
-        }
-
         this.logger.info("Fetched tale:", tale);
         this.tale = tale;
 

--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -205,6 +205,12 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.detectTaleId();
       this.detectCurrentTab();
 
+      this.tokenService.currentUser.subscribe((user: User) => {
+        if (!user && !this.tale.public) {
+          this.router.navigate(['public'])
+        }
+      });
+
       this.taleInstanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe(this.updateInstance);
       this.taleInstanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe(this.updateInstance);
       this.taleInstanceErrorSubscription = this.syncService.instanceErrorSubject.subscribe(this.updateInstance);

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.ts
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectorRef, Component, Input, NgZone, OnChanges } from '@angular
 import { Instance } from '@api/models/instance';
 import { Tale } from '@api/models/tale';
 import { InstanceService } from '@api/services/instance.service';
+import { TokenService } from '@api/token.service';
 import { enterZone } from '@shared/core';
 
 @Component({
@@ -15,10 +16,11 @@ export class TaleInteractComponent implements OnChanges {
 
   constructor(private ref: ChangeDetectorRef,
               private zone: NgZone,
-              private instanceService: InstanceService) {  }
+              private instanceService: InstanceService,
+              private tokenService: TokenService) {  }
 
   ngOnChanges(): void {
-    if (this.tale) {
+    if (this.tale && this.tokenService?.user?.value) {
       const params = { taleId: this.tale._id };
       this.instanceService.instanceListInstances(params)
                           .pipe(enterZone(this.zone))

--- a/src/app/api/token.interceptor.ts
+++ b/src/app/api/token.interceptor.ts
@@ -2,6 +2,8 @@ import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { ApiConfiguration } from '@api/api-configuration';
+import { OauthService } from '@api/services/oauth.service';
+import { LogService } from '@shared/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 
@@ -11,7 +13,30 @@ import { TokenService } from './token.service';
 
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
-  constructor(public tokenService: TokenService, private readonly config: ApiConfiguration, private readonly router: Router) {}
+  constructor(
+    public tokenService: TokenService,
+    private readonly config: ApiConfiguration,
+    private readonly router: Router,
+    private readonly logger: LogService,
+    private readonly oauth: OauthService
+  ) {}
+
+  redirectToLogin(): void {
+    // route to login, redirect back here after auth
+    const redirect = encodeURIComponent(window.location.href);
+
+    const params = { redirect: `${window.location.origin}/?token={girderToken}&rd=${redirect}`, list: false };
+    this.oauth.oauthListProviders(params).subscribe(
+      (providers: { Globus: string; Github: string }) => {
+        // TODO: How to support multiple providers here?
+        window.location.href = providers.Globus;
+      },
+      (err) => {
+        this.logger.error('Failed to GET /oauth/providers:', err);
+      }
+    );
+  }
+
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     // Ignore if we don't have a token
     const token = this.tokenService.getToken();
@@ -20,9 +45,7 @@ export class TokenInterceptor implements HttpInterceptor {
         retry(1),
         catchError((error: HttpErrorResponse) => {
           if (error.status === 401) {
-            // refresh token plz
-            const lastRoute = encodeURIComponent(window.origin);
-            this.router.navigate(['login', { queryParams: { rd: lastRoute } }]);
+            this.redirectToLogin();
           } else {
             return throwError(error);
           }
@@ -50,8 +73,8 @@ export class TokenInterceptor implements HttpInterceptor {
     // For everything else, attach our girder token as a header
     const authRequest = request.clone({
       setHeaders: {
-        'Girder-Token': token
-      }
+        'Girder-Token': token,
+      },
     });
 
     // return next.handle(authRequest);
@@ -59,9 +82,7 @@ export class TokenInterceptor implements HttpInterceptor {
       retry(1),
       catchError((error: HttpErrorResponse) => {
         if (error.status === 401) {
-          // refresh token plz
-          const lastRoute = encodeURIComponent(window.origin);
-          this.router.navigate(['login', { queryParams: { rd: lastRoute } }]);
+          this.redirectToLogin();
         } else {
           return throwError(error);
         }

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -147,7 +147,9 @@ export class HeaderComponent extends BaseComponent implements OnInit, OnDestroy,
         const rd = this.route.snapshot.queryParams.rd;
         if (rd) {
           const route = rd.split(window.origin)[1];
-          this.router.navigateByUrl(route);
+          this.router.navigateByUrl(route).then(() => {
+            this.notificationStream.connect();
+          });
 
           return;
         }

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -147,11 +147,8 @@ export class HeaderComponent extends BaseComponent implements OnInit, OnDestroy,
         const rd = this.route.snapshot.queryParams.rd;
         if (rd) {
           const route = rd.split(window.origin)[1];
-          this.router.navigateByUrl(route).then(() => {
-            this.notificationStream.connect();
-          });
 
-          return;
+          return this.router.navigateByUrl(route);
         }
 
         // If we didn't redirect, we need to enable the navbar dropdown and check for changes

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, NgZone, OnChanges, SimpleChanges } from '@angular/core';
+import { ChangeDetectorRef, Component, NgZone } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { EventData } from '@api/events/event-data';
 import { GirderEvent } from '@api/events/girder-event';
@@ -17,7 +17,7 @@ declare var $: any;
   templateUrl: './notification-stream.component.html',
   styleUrls: ['./notification-stream.component.scss'],
 })
-export class NotificationStreamComponent implements OnChanges {
+export class NotificationStreamComponent {
   constructor(
     private readonly ref: ChangeDetectorRef,
     private readonly zone: NgZone,
@@ -55,12 +55,6 @@ export class NotificationStreamComponent implements OnChanges {
 
   get showNotificationStream(): Boolean {
     return this.notificationStream.showNotificationStream;
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes?.token?.currentValue !== changes?.token?.previousValue) {
-      this.notificationStream.connect();
-    }
   }
 
   ackAll(): void {

--- a/src/app/layout/notification-stream/notification-stream.component.ts
+++ b/src/app/layout/notification-stream/notification-stream.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectorRef, Component, NgZone } from '@angular/core';
+import { ChangeDetectorRef, Component, NgZone, OnInit } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { EventData } from '@api/events/event-data';
 import { GirderEvent } from '@api/events/girder-event';
+import { TokenService } from '@api/token.service';
 import { LogService } from '@shared/core';
 import { SyncService } from '@tales/sync.service';
 import { EventSourcePolyfill as EventSource } from 'ng-event-source';
@@ -17,20 +18,25 @@ declare var $: any;
   templateUrl: './notification-stream.component.html',
   styleUrls: ['./notification-stream.component.scss'],
 })
-export class NotificationStreamComponent {
+export class NotificationStreamComponent implements OnInit {
   constructor(
     private readonly ref: ChangeDetectorRef,
     private readonly zone: NgZone,
     private readonly sync: SyncService,
     private readonly logger: LogService,
     private readonly dialog: MatDialog,
-    private readonly notificationStream: NotificationStreamService
-  ) {
-    if (this.source) {
-      this.source.onmessage = (event: GirderEvent) => {
-        this.onMessage.call(this, event);
-      };
-    }
+    private readonly notificationStream: NotificationStreamService,
+    private readonly tokenService: TokenService
+  ) {}
+
+  ngOnInit(): void {
+    this.tokenService.currentUser.subscribe(() => {
+      if (this.tokenService.user.value) {
+        this.notificationStream.connect(this.onMessage.bind(this), false);
+      } else {
+        this.notificationStream.disconnect();
+      }
+    });
   }
 
   get token(): string {

--- a/src/app/layout/notification-stream/notification-stream.service.ts
+++ b/src/app/layout/notification-stream/notification-stream.service.ts
@@ -27,8 +27,6 @@ class NotificationStreamService implements OnDestroy {
   ackAll() {
     const newSince = new Date().getTime() / 1000;
     this.since = newSince;
-    //this.reconnect(true);
-    //this.connect();
     this.openNotificationStream(false);
     this.events = [];
   }
@@ -92,14 +90,14 @@ class NotificationStreamService implements OnDestroy {
     this.disconnect();
   }
 
-  disconnect(silent: boolean = false) {
+  disconnect(silent: boolean = true) {
     silent || this.logger.warn('Disconnecting now...');
     this.source?.close();
 
     this.source = undefined;
   }
 
-  connect(callback: Function, silent: boolean = false) {
+  connect(callback: Function, silent: boolean = true) {
     // Disconnect, if necessary
     if (this.source) {
       this.disconnect();

--- a/src/app/layout/notification-stream/notification-stream.service.ts
+++ b/src/app/layout/notification-stream/notification-stream.service.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 import { Injectable, OnDestroy } from '@angular/core';
 import { ApiConfiguration } from '@api/api-configuration';
+import { GirderEvent } from '@api/events/girder-event';
 import { LogService } from '@shared/core';
 
 import { TokenService } from '@api/token.service';
@@ -13,10 +14,10 @@ import { bypassSanitizationTrustResourceUrl } from '@angular/core/src/sanitizati
 class NotificationStreamService implements OnDestroy {
   static readonly Path = '/notification/stream';
   static readonly TimeoutMs = 85;
-  static readonly IntervalDelayMs = 85000;
+  // static readonly IntervalDelayMs = 85000;
   private _since: number = 0;
 
-  interval: any;
+  // interval: any;
 
   source: EventSource;
   events: Array<any> = [];
@@ -60,6 +61,14 @@ class NotificationStreamService implements OnDestroy {
     return this.tokenService.getToken();
   }
 
+  get headers() {
+    return { 'Girder-Token': this.token };
+  }
+
+  get eventSourceParams() {
+    return { headers: this.headers, heartbeatTimeout: 90000 };
+  }
+
   get url() {
     let url = this.config.rootUrl + NotificationStreamService.Path;
 
@@ -76,45 +85,41 @@ class NotificationStreamService implements OnDestroy {
     return url;
   }
 
-  constructor(private config: ApiConfiguration, private tokenService: TokenService, private logger: LogService) {
-    this.tokenService.currentUser.subscribe(() => {
-      this.connect(false);
-    });
-  }
+  constructor(private config: ApiConfiguration, private tokenService: TokenService, private logger: LogService) {}
 
   ngOnDestroy() {
-    clearInterval(this.interval);
+    // clearInterval(this.interval);
     this.disconnect();
   }
 
   disconnect(silent: boolean = false) {
-    if (this.source) {
-      silent || this.logger.warn('Disconnecting now...');
-      this.source.close();
-    }
+    silent || this.logger.warn('Disconnecting now...');
+    this.source?.close();
+
+    this.source = undefined;
   }
 
-  connect(silent: boolean = false) {
+  connect(callback: Function, silent: boolean = false) {
     // Disconnect, if necessary
-    this.disconnect();
+    if (this.source) {
+      this.disconnect();
+    }
 
     const token = this.token;
     if (token) {
       silent || this.logger.warn('Connecting now...');
 
       // Connect to SSE using the given parameters
-      this.source = new EventSource(this.url, { headers: { 'Girder-Token': this.token }, heartbeatTimeout: 90000 });
+      this.source = new EventSource(this.url, this.eventSourceParams);
 
       this.source.onerror = this.onError.bind(this);
       this.source.onopen = this.onOpen.bind(this);
+      this.source.onmessage = (event: GirderEvent) => {
+        callback(event);
+      };
+    } else {
+      silent || this.logger.warn('No token, skipping connection...');
     }
-  }
-
-  reconnect(silent: boolean = false) {
-    silent || this.logger.warn('Reconnecting now...');
-    this.disconnect();
-    this.connect();
-    silent || this.logger.warn('Reconnected.');
   }
 
   onError(err: any) {

--- a/src/app/layout/notification-stream/notification-stream.service.ts
+++ b/src/app/layout/notification-stream/notification-stream.service.ts
@@ -77,7 +77,9 @@ class NotificationStreamService implements OnDestroy {
   }
 
   constructor(private config: ApiConfiguration, private tokenService: TokenService, private logger: LogService) {
-    this.connect();
+    this.tokenService.currentUser.subscribe(() => {
+      this.connect(false);
+    });
   }
 
   ngOnDestroy() {
@@ -85,19 +87,21 @@ class NotificationStreamService implements OnDestroy {
     this.disconnect();
   }
 
-  disconnect(silent: boolean = true) {
-    silent || this.logger.debug('Disconnecting now...');
+  disconnect(silent: boolean = false) {
     if (this.source) {
+      silent || this.logger.warn('Disconnecting now...');
       this.source.close();
     }
   }
 
-  connect(silent: boolean = true) {
+  connect(silent: boolean = false) {
     // Disconnect, if necessary
     this.disconnect();
 
-    silent || this.logger.debug('Connecting now...');
-    if (this.token) {
+    const token = this.token;
+    if (token) {
+      silent || this.logger.warn('Connecting now...');
+
       // Connect to SSE using the given parameters
       this.source = new EventSource(this.url, { headers: { 'Girder-Token': this.token }, heartbeatTimeout: 90000 });
 
@@ -106,11 +110,11 @@ class NotificationStreamService implements OnDestroy {
     }
   }
 
-  reconnect(silent: boolean = true) {
-    silent || this.logger.debug('Reconnecting now...');
+  reconnect(silent: boolean = false) {
+    silent || this.logger.warn('Reconnecting now...');
     this.disconnect();
     this.connect();
-    silent || this.logger.debug('Reconnected.');
+    silent || this.logger.warn('Reconnected.');
   }
 
   onError(err: any) {

--- a/src/app/shared/error-handler/server-error.interceptor.ts
+++ b/src/app/shared/error-handler/server-error.interceptor.ts
@@ -1,22 +1,37 @@
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { OauthService } from '@api/services/oauth.service';
 import { LogService } from '@shared/core/log.service';
 import { Observable, throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 
 @Injectable()
 export class ServerErrorInterceptor implements HttpInterceptor {
-  constructor(private readonly logger: LogService, private readonly router: Router /*, private readonly auth: AuthService */) {}
+  constructor(private readonly logger: LogService, private readonly router: Router, private readonly oauth: OauthService) {}
+
+  redirectToLogin(): void {
+    // route to login, redirect back here after auth
+    const redirect = encodeURIComponent(window.location.href);
+
+    const params = { redirect: `${window.location.origin}/?token={girderToken}&rd=${redirect}`, list: false };
+    this.oauth.oauthListProviders(params).subscribe(
+      (providers: { Globus: string; Github: string }) => {
+        // TODO: How to support multiple providers here?
+        window.location.href = providers.Globus;
+      },
+      (err) => {
+        this.logger.error('Failed to GET /oauth/providers:', err);
+      }
+    );
+  }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(
       retry(1),
       catchError((error: HttpErrorResponse) => {
         if (error.status === 401) {
-          // refresh token plz
-          const lastRoute = encodeURIComponent(window.origin);
-          this.router.navigate(['login', { queryParams: { rd: lastRoute } }]);
+          this.redirectToLogin();
         } else {
           return throwError(error);
         }


### PR DESCRIPTION
## Problem
Some remaining problems still linger after merging #277 and #282. Namely

Fixes #283 - `notification-stream` sometimes does not display when launching a Tale, events are not handled properly
Fixes #284 - silent 401 error in the console when attempting to access a private Tale before logging in
Fixes #285 - user can still view stale data after logging out when viewing a private Tale

## Approach

* #283 - Reconnect to `notification-stream` when user is logged in, disconnect on logout
* #284 - Re-route to login automatically if user attempts to access a private Tale
* #285 - Logout while on private Tale's Run view now redirects to `/public` after logout

## How to Test
Prerequisites: logged out, at least one Tale (private; not public, not shared)

1. Checkout this branch locally, rebuild the dashboard
2. Navigate directly to `/mine` (without logging in)
    * You should be redirected to the login flow (via Globus)
3. Follow the login flow until you're logged in
    * You should be brought to `/mine` on the WholeTale Dashboard
4. Without navigating or refreshing, Launch a Tale
    * #283 - You should see the `notification-stream` appears without needing to refresh the page
5. Wait for the Tale to launch
    * Once the Tale has started, you should see the Interact tab automatically re-renders without needing to refresh the page
6. Save the `/run/:id` URL from your address bar for later (see step 8)
7. At the top-right, expand the User dropdown and click Logout
    * #285 - You should be redirected to `/public`, since this Tale is private and you are no longer authorized to view it after logging out
8. Navigate back to the `/run/:id` view by directly pasting the URL you saved previously
    * #284 - You should be rerouted through the login flow and end up on the `/run/:id` view, now authorized to view it