### PR TITLE
Remove "with Globus" (for now)

### DIFF
--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -17,8 +17,8 @@
             {{ eventCount }}
         </div>
       </a>
-      <a *ngIf="!user" class="item" (click)="loginWith('Globus')" matTooltip="Sign In with Globus">
-        <i class="user white icon"></i> Sign In with Globus
+      <a *ngIf="!user" class="item" (click)="loginWith('Globus')" matTooltip="Sign In">
+        <i class="user white icon"></i> Sign In
       </a>
       <!--<a *ngIf="!user" class="item" (click)="loginWith('Github')" matTooltip="Sign In with Github">
         <i class="github white icon"></i> Sign In with Github


### PR DESCRIPTION
## Problem
Since we only offer Globus auth now, there's no need to have the "Sign In with Globus".

## Approach
Remove "with Globus" until we offer additional options.

## How to Test
* Rebuild with this branch
* Open private window and confirm "Sign In" button appears. 
