### PR TITLE
fix: create folder without refresh, fix dropdowns after rename folder

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -206,8 +206,8 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
       this.detectCurrentTab();
 
       this.tokenService.currentUser.subscribe((user: User) => {
-        if (!user && !this.tale.public) {
-          this.router.navigate(['public'])
+        if (!user && !this.tale?.public) {
+          this.router.navigate(['public']);
         }
       });
 

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -383,6 +383,14 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
     })();
   }
 
+  initDropdowns(): void {
+    setTimeout(() => {
+      $('.ui.file.dropdown').dropdown({ action: 'hide' });
+      this.load();
+    }, 500);
+
+  }
+
 
   load(): void {
     // Already loading, short-circuit
@@ -401,6 +409,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
                                                   .subscribe((values: Array<any>) => {
                                                     this.folders.next(values[0]);
                                                     this.files.next(values[1]);
+                                                    this.initDropdowns();
                                                     this.loading = false;
                                                     this.ref.detectChanges();
                                                   });
@@ -416,6 +425,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
                          if (this.currentNav === 'recorded_runs') {
                            this.folders.next(r.sort(sortByUpdated));
                            this.files.next([]);
+                           this.initDropdowns();
                            this.loading = false;
                            this.ref.detectChanges();
                          }
@@ -428,6 +438,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
                              if (this.currentNav === 'tale_versions') {
                                this.folders.next(v.sort(sortByUpdated));
                                this.files.next([]);
+                               this.initDropdowns();
                                this.loading = false;
                                this.ref.detectChanges();
                              }
@@ -451,6 +462,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
           if (this.currentNav === 'home') {
             this.folders.next(values[0]);
             this.files.next(values[1]);
+            this.initDropdowns();
             this.loading = false;
             this.ref.detectChanges();
           }
@@ -467,6 +479,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
         if (this.tale.dataSet.length === 0) {
           this.folders.next([]);
           this.files.next([]);
+          this.initDropdowns();
           this.loading = false;
           this.ref.detectChanges();
 
@@ -489,6 +502,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
 
             this.folders.next(folderMatches);
             this.files.next(itemMatches);
+            this.initDropdowns();
             this.loading = false;
             this.ref.detectChanges();
           }
@@ -521,6 +535,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
           if (this.currentNav === 'tale_workspace') {
             this.folders.next(values[0]);
             this.files.next(values[1]);
+            this.initDropdowns();
             this.loading = false;
             this.ref.detectChanges();
           }
@@ -690,9 +705,11 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
                       .pipe(enterZone(this.zone))
                       .subscribe(
       newFolder => {
-        const folders = this.folders.value;
-        folders.push(newFolder);
-        this.folders.next(folders);
+        //const folders = this.folders.value;
+        //folders.push(newFolder);
+        //this.folders.next(folders);
+
+        this.load();
       },
       err => this.dialog.open(ErrorModalComponent, { data: { error: err.error } }));
   }
@@ -806,14 +823,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
       this.folderService.folderUpdateFolder(params).pipe(enterZone(this.zone))
                         .subscribe(resp => {
         this.logger.debug("Folder renamed successfully:", resp);
-        const folders =  this.folders.value;
-        const index = folders.indexOf(element);
-        folders[index] = resp;
-        this.folders.next(folders);
-
-        setTimeout(() => {
-          $('.ui.file.dropdown').dropdown({ action: 'hide' });
-        }, 500);
+        this.load();
       }, err => {
         // Rename failed, roll-back the change
         element.name = element.prevName;

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -386,9 +386,7 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
   initDropdowns(): void {
     setTimeout(() => {
       $('.ui.file.dropdown').dropdown({ action: 'hide' });
-      this.load();
     }, 500);
-
   }
 
 


### PR DESCRIPTION
## Problem
Some issues with the file browser:
* #299: When user creates a folder it does not immediately appear in the file browser
* #297: When user renames a folder it breaks the dropdown menu of that folder

Fixes #299
Fixes #297

## Approach
* Call `this.load()` after folder creation, rather than manually adding the new folder to the list - this will force a full refresh of the contents of the file browser
* Call `this.initDropdowns()` in every possible callback of `load()` - we should rely on calling `this.load()` anytime the user makes a change to directory structure (e.g. copy, move, rename, upload, create, etc) and this should correctly re-init all of the dropdowns on the file browser if any DOM elements need to be re-rendered (which somehow breaks their dropdown menu)

## How to Test
Prerequisites: at least one Tale to which you have write access

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run Tale > Files > Tale Workspace (or Home) for a Tale that you can modify
4. Create a folder
    * #299: You should see the folder appear almost immediately (without needing to manually refresh the page)
5. Expand the dropdown by clicking the [v] beside the folder you just created
    * You should see the dropdown appears as expected
7. Rename the folder you just created
    * You should see the name change almost immediately
8. Expand the dropdown once more by clicking the [v] 
    * #297: You should see the dropdown still appears as expected