### PR TITLE
fix: interact tab should route user through login if needed

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.ts
+++ b/src/app/+run-tale/run-tale/run-tale.component.ts
@@ -176,6 +176,12 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
 
         this.refreshCollaborators();
 
+        this.tokenService.currentUser.subscribe((user: User) => {
+          if (!user && !this.tale.public) {
+            this.router.navigate(['']);
+          }
+        });
+
         this.userService.userGetUser(this.tale.creatorId)
                       .subscribe(creator => {
           this.creator = creator;
@@ -204,12 +210,6 @@ export class RunTaleComponent extends BaseComponent implements OnInit, OnChanges
     ngOnInit(): void {
       this.detectTaleId();
       this.detectCurrentTab();
-
-      this.tokenService.currentUser.subscribe((user: User) => {
-        if (!user && !this.tale?.public) {
-          this.router.navigate(['public']);
-        }
-      });
 
       this.taleInstanceLaunchingSubscription = this.syncService.instanceLaunchingSubject.subscribe(this.updateInstance);
       this.taleInstanceRunningSubscription = this.syncService.instanceRunningSubject.subscribe(this.updateInstance);

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.html
@@ -2,14 +2,15 @@
 <div class="ui stretched stackable grid" id="tale-interact-container">
   <div class="row">
     <div class="sixteen wide column" *ngIf="instance">
+
       <!-- Launching state -->
-      <div *ngIf="instance.status === 0" class="status-banner">
+      <div *ngIf="tokenService?.user?.value && instance.status === 0" class="status-banner">
         <h3>Tale is launching, please wait...</h3>
         <i class="fas fa-5x fa-spinner fa-pulse"></i>
       </div>
 
       <!-- Running state -->
-      <div *ngIf="instance.status === 1">
+      <div *ngIf="tokenService?.user?.value && instance.status === 1">
         <iframe *ngIf="instance.iframe" height="100%" width="100%" [src]="instance.url | safe:'url'"></iframe>
 
         <div *ngIf="!instance.iframe" class="ui message">
@@ -25,21 +26,28 @@
       </div>
 
       <!-- Error state -->
-      <div *ngIf="instance.status === 2" class="status-banner">
+      <div *ngIf="tokenService?.user?.value && instance.status === 2" class="status-banner">
         <i class="fas fa-exclamation-triangle"></i> Something went wrong.
         Please wait a few moments and try again.
       </div>
 
       <!-- Deleting state -->
-      <div *ngIf="instance.status === 3" class="status-banner">
+      <div *ngIf="tokenService?.user?.value && instance.status === 3" class="status-banner">
         <h3>Tale is stopping, please wait...</h3>
         <i class="fas fa-5x fa-trash fa-spin"></i>
       </div>
     </div>
 
-    <div class="sixteen wide column" *ngIf="!instance">
+    <div class="sixteen wide column" *ngIf="tokenService?.user?.value && !instance">
       <div class="status-banner">
         <h3>You must Run this Tale before you can Interact.</h3>
+      </div>
+    </div>
+
+    <!-- User is not logged in -->
+    <div class="sixteen wide column" *ngIf="!tokenService?.user?.value">
+      <div class="status-banner">
+        <h3>You must Sign In before you can Interact.</h3>
       </div>
     </div>
   </div>

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.ts
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.ts
@@ -17,10 +17,10 @@ export class TaleInteractComponent implements OnChanges {
   constructor(private ref: ChangeDetectorRef,
               private zone: NgZone,
               private instanceService: InstanceService,
-              private tokenService: TokenService) {  }
+              public tokenService: TokenService) {  }
 
   ngOnChanges(): void {
-    if (this.tale && this.tokenService?.user?.value) {
+    if (this.tale) {
       const params = { taleId: this.tale._id };
       this.instanceService.instanceListInstances(params)
                           .pipe(enterZone(this.zone))


### PR DESCRIPTION
## Problem
An unauthenticated user can end up on the Interact tab, which does not work properly if the user is not logged in.

Fixes #296

## Approach
* Force users to login if they reach the Interact tab without doing so (note that Interact tab is hidden from UI if user is not logged in)
* Add a message to the Interact page that the user must Sign In to Interact - just in case the automatic redirect fails

## How to Test
Prerequisites: at least one public Tale

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Create a Tale, if you haven't already
4. Mark the Tale as public
5. Navigate to the Interact tab and copy the URL
6. Sign out and open a new incognito window
7. Paste the Interact URL that you saved previously
    * You should be prompted to log in
8. Enter your credentials (2FA, etc) and sign in
    * You should end up on the Interact tab, as an authenticated user