### PR TITLE
fix: tale version panel height, file-browser loading indicator, css prettification on all of run-tale view

### DIFF
--- a/src/app/+run-tale/run-tale/run-tale.component.html
+++ b/src/app/+run-tale/run-tale/run-tale.component.html
@@ -78,7 +78,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="ui secondary pointing menu" style="margin-top: 0;">
+                    <div class="ui secondary pointing menu">
                         <a class="item" [ngClass]="{ 'active': isTabActive('interact') }" (click)="switchTab('interact')" *ngIf="tokenService?.user?.value">
                           Interact
                         </a>

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -168,9 +168,6 @@ app-tale-versions-panel {
 .wt-panel:nth-child(2) {
   margin-top: 1rem;
 }
-.wt-panel .wt-panel-body .ui.grid .row .wide.column > div {
-  height: 99.4%;
-}
 
 .wt-panel-body > .ui.grid > .row {
   padding-top: 0;

--- a/src/app/+run-tale/run-tale/run-tale.component.scss
+++ b/src/app/+run-tale/run-tale/run-tale.component.scss
@@ -22,12 +22,21 @@
   margin: 12pt 0 0 0;
 }
 
+.ui.secondary.pointing.menu {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 .ui.breadcrumb a {
   color: #333;
 }
 
 .panel-container {
   width: 100%;
+}
+
+.panel-container > .row {
+  padding-top: 0;
 }
 
 .tale-run-button {
@@ -163,6 +172,11 @@ app-tale-versions-panel {
   height: 99.4%;
 }
 
+.wt-panel-body > .ui.grid > .row {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .wt_panel_body > .ui.grid,
 .wt_panel_body > .ui.grid > .row,
 .wt_panel_body > .ui.grid > .row > .column {
@@ -173,10 +187,16 @@ app-tale-versions-panel {
 
 .ui.grid {
   height: 100%;
+  margin: 0;
 }
 
 .wt-panel > .wt-panel-body > .row {
   padding-bottom: 0 !important;
+}
+
+.four.wide.column {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .ui.stretched.stackable.grid.panel-container {
@@ -184,9 +204,6 @@ app-tale-versions-panel {
   height: auto;
 }
 
-.wt-panel .wt-panel-body {
-  height: 88%;
-}
 .wt-panel .wt-panel-body.bg-grey,
 .wt-panel .wt-panel-header.bg-grey {
   background-color: #f9fafb;

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.html
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.html
@@ -49,6 +49,7 @@
 
 
       <app-file-explorer id="tale-files-browser"
+        [loading]="loading"
         [fileElements]="folders?.value?.concat(files?.value)"
         [sanitizeId]="sanitizeId"
         [path]="currentPath"

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.scss
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.scss
@@ -3,7 +3,6 @@
   //min-height: 60vh;
   height: 100%;
   margin-top: 0;
-  margin-bottom: 0;
 }
 
 #tale-files-browser {

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.scss
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.scss
@@ -2,6 +2,8 @@
   //height: calc(60vh - 64px);
   //min-height: 60vh;
   height: 100%;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 #tale-files-browser {
@@ -22,7 +24,6 @@
 }
 
 .twelve.wide.column > .ui.segment {
-  border-radius: 0 0 10pt 0;
   box-shadow: none;
 }
 
@@ -39,9 +40,7 @@
 
 .four.wide.column,
 .twelve.wide.column {
-  padding-top: 0;
-  padding-left: 0;
-  padding-bottom: 0;
+  padding: 0;
 }
 
 .ui.grid {

--- a/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.scss
+++ b/src/app/+run-tale/run-tale/tale-interact/tale-interact.component.scss
@@ -2,6 +2,7 @@
   //height: calc(60vh - 64px);
   //overflow: auto;
   //min-height: 60vh;
+  margin-top: 0;
   height: 100%;
 }
 
@@ -11,10 +12,12 @@
 
 .ui.grid > .row {
   padding-top: 0;
+  padding-bottom: 0;
 }
 
 .ui.grid > .row > .column {
   padding-left: 0;
+  padding-right: 0;
 }
 
 .status-banner {
@@ -35,4 +38,5 @@
 
 iframe {
   border: none;
+  height: 65vh;
 }

--- a/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.scss
+++ b/src/app/+run-tale/run-tale/tale-metadata/tale-metadata.component.scss
@@ -1,6 +1,7 @@
 #tale-metadata-container {
   //min-height: 60vh;
   height: 100%;
+  margin-top: 0;
   padding: 2rem 2rem 0 2rem;
 }
 

--- a/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.scss
+++ b/src/app/+run-tale/run-tale/tale-sharing/tale-sharing.component.scss
@@ -1,3 +1,8 @@
+#tale-sharing-container {
+  height: 100%;
+  margin-top: 0;
+}
+
 .ui.radio.checkbox .box,
 .ui.radio.checkbox label {
   padding-left: 1.85714em;

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -17,7 +17,7 @@
   <h3>Tale History</h3>
 
   <div id="timeline" class="ui middle aligned divided list">
-    <div class="ui message" style="height:100%;" *ngIf="!timeline.length">
+    <div class="ui message" *ngIf="!timeline.length">
       No previous versions saved for Tale.
     </div>
 

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.html
@@ -16,7 +16,7 @@
 
   <h3>Tale History</h3>
 
-  <div id="timeline" class="ui middle aligned divided list" style="height:100%;">
+  <div id="timeline" class="ui middle aligned divided list">
     <div class="ui message" style="height:100%;" *ngIf="!timeline.length">
       No previous versions saved for Tale.
     </div>

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.scss
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.scss
@@ -1,5 +1,5 @@
 #timeline-column {
-  padding: 0 1rem 1rem;
+  padding: 0;
   border-left: 1px solid #ddd;
 }
 #timeline-column h3 {
@@ -10,7 +10,7 @@
   font-weight: 700;
 }
 #timeline-column > .vertical.segment {
-  padding-top: 0;
+  padding: 10pt;
 }
 
 #timeline {

--- a/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.scss
+++ b/src/app/+run-tale/run-tale/tale-versions-panel/tale-versions-panel.component.scss
@@ -14,8 +14,8 @@
 }
 
 #timeline {
-  height: calc(100vh - 500px);
-  overflow: scroll;
+  height: 45vh;
+  overflow: auto;
   padding: 0 1rem;
 }
 #timeline .item {

--- a/src/app/files/file-explorer/file-explorer.component.html
+++ b/src/app/files/file-explorer/file-explorer.component.html
@@ -43,62 +43,65 @@
 <input #file multiple type="file" style="display: none" (change)="onUploadsAdded($event)" />
 
 <div class="container" fxFlex fxLayout="column" fxLayoutAlign="space-between stretch">
-  <!-- Show placeholder if there are no fileElements to display -->
-  <div class="ui message" *ngIf="!fileElements || !fileElements.length">
-    {{ placeholderMessage }}
-  </div>
+  <div class="dimmable">
+    <div *ngIf="loading" class="ui active center aligned inverted dimmer">
+      <div class="ui loader"></div>
+    </div>
+    <!-- Show placeholder if there are no fileElements to display -->
+    <div class="ui message" *ngIf="!fileElements || !fileElements.length">
+      {{ placeholderMessage }}
+    </div>
+    <!-- Show folders/files in table if any exist -->
+    <table class="ui basic selectable very compact blue table" *ngIf="fileElements && fileElements.length">
+      <thead>
+        <tr>
+          <th class="col-icon"></th>
+          <th class="col-name">Name</th>
+          <th class="col-status" *ngIf="currentNav==='recorded_runs' && !canNavigateUp">Status</th>
+          <th class="col-updated">Updated</th>
+          <th class="col-size right aligned">Size</th>
+          <th class="col-more">More</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let ele of fileElements; index as i; trackBy: trackById" (click)="navigate(ele)"
+            [ngClass]="{ 'active': this.highlighted === ele._id }"
+            [ngStyle]="{ 'cursor': getIcon(ele) === 'fa-folder' ? 'pointer' : 'inherit' }">
+          <th class="center aligned"><i class="fas fa-fw fa-2x {{ getIcon(ele) }}"></i></th>
+          <td [title]="ele.name">{{ ele.name | truncate:100 }}</td>
 
-
-  <!-- Show folders/files in table if any exist -->
-  <table class="ui basic selectable very compact blue table" *ngIf="fileElements && fileElements.length">
-    <thead>
-      <tr>
-        <th width="5%"></th>
-        <th width="45%">Name</th>
-        <th *ngIf="currentNav==='recorded_runs' && !canNavigateUp" width="20%">Status</th>
-        <th width="15%">Updated</th>
-        <th width="10%" class="right aligned">Size</th>
-        <th width="5%">More</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let ele of fileElements; index as i; trackBy: trackById" (click)="navigate(ele)"
-          [ngClass]="{ 'active': this.highlighted === ele._id }"
-          [ngStyle]="{ 'cursor': getIcon(ele) === 'fa-folder' ? 'pointer' : 'inherit' }">
-        <th class="center aligned"><i class="fas fa-fw fa-2x {{ getIcon(ele) }}"></i></th>
-        <td [title]="ele.name">{{ ele.name | truncate:100 }}</td>
-
-        <td *ngIf="ele.runStatus !== undefined">
-          <span *ngIf="ele.runStatus === 0"><i class="fa fa-fw fa-question yellow"></i> UNKNOWN</span>
-          <span *ngIf="ele.runStatus === 1"><i class="fa fa-fw fa-spinner fa-pulse yellow"></i> STARTING</span>
-          <span *ngIf="ele.runStatus === 2"><i class="fa fa-fw fa-sync-alt fa-spin blue"></i> RUNNING</span>
-          <span *ngIf="ele.runStatus === 3"><i class="fa fa-fw fa-check green"></i> COMPLETED</span>
-          <span *ngIf="ele.runStatus === 4"><i class="fa fa-fw fa-times red"></i> FAILED</span>
-          <span *ngIf="ele.runStatus === 5"><i class="fa fa-fw fa-ban red"></i> CANCELLED</span>
-        </td>
-        <td [title]="ele.updated">{{ ele.updated | date }}</td>
-        <td class="right aligned" [title]="ele.folderId === currentUpload?.parentId && ele.name === currentUpload?.name ? (currentUpload.uploadProgress | number) + '%' : ele.size">
-          <span *ngIf="ele.folderId !== currentUpload?.parentId || ele.name !== currentUpload?.name">{{ ele.size | fileSize }}</span>
-          <small *ngIf="ele.folderId === currentUpload?.parentId && ele.name === currentUpload?.name"><i id="in-progress-upload-icon" class="fas fa-fw fa-spinner fa-pulse"></i> Uploading... {{ currentUpload.uploadProgress | number }}%</small>
-          <div *ngIf="ele.folderId === currentUpload?.parentId && ele.name === currentUpload?.name" id="in-progress-upload-bar" class="ui indicating progress" [attr.data-percent]="currentUpload.uploadProgress | number">
-              <div class="bar"></div>
-          </div>
-        </td>
-        <td class="center aligned">
-          <div [id]="sanitizeId('more-actions-' + ele._id)" class="ui inline file dropdown more-actions" (click)="openMenu($event, ele)" *ngIf="showContextMenu">
-            <!--<div class="text">More</div>-->
-            <i class="dropdown icon"></i>
-            <div class="left menu">
-              <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions') || !canNavigateUp)" class="item" (click)="renameElement(ele)"><i class="fas fa-fw fa-edit"></i> Rename</div>
-              <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions') || !canNavigateUp)" class="item" (click)="removeElement(ele)"><i class="fas fa-fw fa-trash"></i> Remove</div>
-              <div class="item" (click)="downloadElement(ele)"><i class="fas fa-fw fa-download"></i> Download</div>
-              <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions'))" class="item" (click)="openMoveToDialog(ele)"><i class="fas fa-fw fa-exchange-alt"></i> Move To...</div>
-              <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions'))" class="item" (click)="copyElement(ele)"><i class="fas fa-fw fa-clone"></i> Copy</div>
-              <div *ngIf="currentNav === 'tale_versions'" class="item" (click)="copyTaleVersion(ele._id)"><i class="fas fa-fw fa-clone"></i> As New Tale</div>
+          <td *ngIf="ele.runStatus !== undefined">
+            <span *ngIf="ele.runStatus === 0"><i class="fa fa-fw fa-question yellow"></i> UNKNOWN</span>
+            <span *ngIf="ele.runStatus === 1"><i class="fa fa-fw fa-spinner fa-pulse yellow"></i> STARTING</span>
+            <span *ngIf="ele.runStatus === 2"><i class="fa fa-fw fa-sync-alt fa-spin blue"></i> RUNNING</span>
+            <span *ngIf="ele.runStatus === 3"><i class="fa fa-fw fa-check green"></i> COMPLETED</span>
+            <span *ngIf="ele.runStatus === 4"><i class="fa fa-fw fa-times red"></i> FAILED</span>
+            <span *ngIf="ele.runStatus === 5"><i class="fa fa-fw fa-ban red"></i> CANCELLED</span>
+          </td>
+          <td [title]="ele.updated">{{ ele.updated | date }}</td>
+          <td class="right aligned" [title]="ele.folderId === currentUpload?.parentId && ele.name === currentUpload?.name ? (currentUpload.uploadProgress | number) + '%' : ele.size">
+            <span *ngIf="ele.folderId !== currentUpload?.parentId || ele.name !== currentUpload?.name">{{ ele.size | fileSize }}</span>
+            <small *ngIf="ele.folderId === currentUpload?.parentId && ele.name === currentUpload?.name"><i id="in-progress-upload-icon" class="fas fa-fw fa-spinner fa-pulse"></i> Uploading... {{ currentUpload.uploadProgress | number }}%</small>
+            <div *ngIf="ele.folderId === currentUpload?.parentId && ele.name === currentUpload?.name" id="in-progress-upload-bar" class="ui indicating progress" [attr.data-percent]="currentUpload.uploadProgress | number">
+                <div class="bar"></div>
             </div>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          </td>
+          <td class="center aligned">
+            <div [id]="sanitizeId('more-actions-' + ele._id)" class="ui inline file dropdown more-actions" (click)="openMenu($event, ele)" *ngIf="showContextMenu">
+              <!--<div class="text">More</div>-->
+              <i class="dropdown icon"></i>
+              <div class="left menu">
+                <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions') || !canNavigateUp)" class="item" (click)="renameElement(ele)"><i class="fas fa-fw fa-edit"></i> Rename</div>
+                <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions') || !canNavigateUp)" class="item" (click)="removeElement(ele)"><i class="fas fa-fw fa-trash"></i> Remove</div>
+                <div class="item" (click)="downloadElement(ele)"><i class="fas fa-fw fa-download"></i> Download</div>
+                <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions'))" class="item" (click)="openMoveToDialog(ele)"><i class="fas fa-fw fa-exchange-alt"></i> Move To...</div>
+                <div *ngIf="!readOnlyDropdown && ((currentNav !== 'recorded_runs' && currentNav !== 'tale_versions'))" class="item" (click)="copyElement(ele)"><i class="fas fa-fw fa-clone"></i> Copy</div>
+                <div *ngIf="currentNav === 'tale_versions'" class="item" (click)="copyTaleVersion(ele._id)"><i class="fas fa-fw fa-clone"></i> As New Tale</div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/src/app/files/file-explorer/file-explorer.component.scss
+++ b/src/app/files/file-explorer/file-explorer.component.scss
@@ -1,13 +1,35 @@
 :host {
-  height: 100%;
   display: flex;
   flex-direction: column;
+  max-height: 65vh;
+  overflow: auto;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.col-icon,
+.col-more {
+  width: 5%;
+}
+
+.col-name {
+  width: 45%;
+}
+
+.col-status {
+  width: 20%;
+}
+
+.col-updated {
+  width: 15%;
+}
+
+.col-size {
+  width: 10%;
 }
 
 mat-toolbar {
@@ -29,7 +51,9 @@ mat-toolbar {
 
 .ui.message {
   width: 100%;
-  height: 100%;
+  height: 58vh;
+  flex-direction: column;
+  display: flex;
   max-width: none;
   border-radius: 0 0 10pt 0;
   box-shadow: none;

--- a/src/app/files/file-explorer/file-explorer.component.ts
+++ b/src/app/files/file-explorer/file-explorer.component.ts
@@ -80,6 +80,7 @@ export class FileExplorerComponent implements OnChanges {
 
   @Input() currentUpload: FileElement;
 
+  @Input() loading = false;
   @Input() preventNavigation = false;
   @Input() readOnly = false;
   @Input() readOnlyDropdown = false;


### PR DESCRIPTION
## Problem
Tale Versions Panel has some odd styling concerns - default size is a bit too small, scroll bars always show even when not needed

Fixes #290 

## Approach
Clean up the styling here to improve the look&feel of the Tale Versions Panel

Default state (no versions created):
<img width="1672" alt="Screen Shot 2022-09-22 at 3 59 41 PM" src="https://user-images.githubusercontent.com/1413653/191850003-ed7f39ae-8ea3-483a-bbd7-17c93ff31096.png">

With one or more versions created (do not show scroll bars):
<img width="1675" alt="Screen Shot 2022-09-22 at 3 58 20 PM" src="https://user-images.githubusercontent.com/1413653/191849828-93916ab0-8760-4dc2-9403-5a1506030198.png">

With many versions created (show scroll bars):
<img width="1680" alt="Screen Shot 2022-09-22 at 3 34 16 PM" src="https://user-images.githubusercontent.com/1413653/191849902-844ec5e2-614f-460e-abc1-f7109c0d10b0.png">

## How to Test
Prerequisites: at least one Tale created that your have access to

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to Run Tale and expand the Tale Versions Panel on the right
    * You should see the Version timeline now has slightly better styling
4. Add a few more versions
    * You should see that scroll bars only appear if timeline content becomes too long to fit on the screen