### PR TITLE
fix: allow to use AinWT with git repo

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/modals/create-tale-modal/create-tale-modal.component.ts
@@ -7,7 +7,7 @@ import { LogService } from '@shared/core';
 // import * as $ from 'jquery';
 declare var $: any;
 
-enum Mode {
+export enum Mode {
   Default = "default",
   Git = "git",
   DOI = "doi",
@@ -58,6 +58,9 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
     };
     this.mode = data.mode as Mode;
     this.baseUrl = (data && data.params && data.params.api) ? decodeURIComponent(data.params.api) : '';
+    if (this.mode === Mode.Git) {
+      this.gitUrl = (data && data.params && data.params.uri) ? decodeURIComponent(data.params.uri) : '';
+    }
 
   }
 
@@ -114,8 +117,7 @@ export class CreateTaleModalComponent implements OnInit, AfterViewInit {
       $('.ui.dropdown').dropdown();
     });
 
-    if (this.data && this.data.params && this.data.params.uri) {
-      this.mode = Mode.AinWT;
+    if (this.data && this.data.params && this.data.params.uri && this.mode === Mode.AinWT) {
       this.zone.run(() => {
         // TODO: Fetch / display data citation from datacite?
         this.datasetCitation = { doi: decodeURIComponent(this.data.params.uri) };

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -12,7 +12,7 @@ import { ErrorModalComponent } from '@shared/error-handler/error-modal/error-mod
 import { Subscription } from 'rxjs';
 import { routeAnimation } from '~/app/shared';
 
-import { CreateTaleModalComponent } from './modals/create-tale-modal/create-tale-modal.component';
+import { CreateTaleModalComponent, Mode } from './modals/create-tale-modal/create-tale-modal.component';
 
 // import * as $ from 'jquery';
 declare var $: any;
@@ -85,9 +85,10 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
             this.router.navigate(this.route.snapshot.url, { replaceUrl: true });
 
             this.zone.run(() => {
+              const modeGit = (queryParams.git ? queryParams.git : 'false') === 'true';
               const dialogRef = this.dialog.open(CreateTaleModalComponent, {
                 width: '600px',
-                data: { params: queryParams }
+                data: { params: queryParams, mode: modeGit ? Mode.Git : Mode.AinWT }
               });
               dialogRef.afterClosed().subscribe((result: {tale: Tale, asTale: boolean, url: string, baseUrl: string}) => {
                 // Short-circuit for 'Cancel' case
@@ -102,7 +103,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
                   url: queryParams.uri ? decodeURIComponent(queryParams.uri) : (result.url ? result.url : ''), // Pull from querystring/form
                   imageId: tale.imageId, // Pull from user input
                   asTale: asTale ? asTale : false, // Pull from user input
-                  git: !!result.url,
+                  git: modeGit,
                   spawn: false, // if true, immediately launch a Tale instance
                   taleKwargs: tale.title ? { title: tale.title } : {},
                   lookupKwargs: baseUrl ? { base_url: baseUrl } : {},


### PR DESCRIPTION
## Problem

Currently it's not possible to initialize AinWT in a "git variant" by crafting an url to pointing to dashboard.

## Approach

1. Modify `CreateTaleModalComponent` to utilize `uri` query parameter if `mode.Git` was selected.
2. In case of AinWT detect whether `git=true/false` parameter was used and choose mode accordingly

## How to Test

1. Checkout this branch locally, rebuild the dashboard
2. Follow https://dashboard.local.wholetale.org/mine?name=AEAREP-3198-Stata&environment=STATA%20%28Desktop%29&uri=https%3A%2F%2Fgithub.com%2FAEADataEditor%2Freplication-template%2F&asTale=true&git=true
3. Git variant of 'create Tale' modal should be opened with prefilled data. Click on "Create a new Tale".
4. A Tale with git repo cloned into the workspace should be created.
5. (BEWARE) While I tested my changes work as intended, I haven't verified that a classic AinWT still works, i.e. I haven't broken all the other things... You may want to check that.