### PR TITLE
feat: notification stream - add a Cancel button beside job progress bar

### DIFF
--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -50,6 +50,7 @@
       <td width="5%">
         <button class="ui tiny negative basic right floated icon button"
                 [disabled]="!event?.data?.resource?.jobs?.length"
+                matTooltip="Cancel"
                 *ngIf="event.data.state === 'active'"
                 (click)="cancelJob(event)">
           <i class="times icon"></i>

--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -34,6 +34,10 @@
           <i class="ui fas fa-fw fa-pause yellow icon"></i>
           Queued<span *ngIf="event.data.message">: {{ event.data.message }}</span>
         </span>
+        <span  *ngSwitchCase="'canceled'">
+          <i class="ui fas fa-fw fa-stop brown icon"></i>
+          Canceled<span *ngIf="event.data.message">: {{ event.data.message }}</span>
+        </span>
         <span  *ngSwitchDefault>
           <i class="ui fas fa-fw fa-ban red icon"></i>
           Error<span *ngIf="event.data.message">: {{ event.data.message }}</span>

--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -13,7 +13,7 @@
       <td width="20%"><label class="ui label">{{ event.data.title || event.type }}</label></td>
 
       <!-- TODO: Truncate name -->
-      <td width="30%" *ngIf="event.data.resource.tale_title" [title]="event.data.resource.tale_title">{{ event.data.resource.tale_title | truncate:20 }}</td>
+      <td width="15%" *ngIf="event.data.resource.tale_title" [title]="event.data.resource.tale_title">{{ event.data.resource.tale_title | truncate:20 }}</td>
       <td width="40%" [ngSwitch]="event.data.state">
         <div class="ui small teal indicating progress event-progress nomargin" *ngSwitchCase="'active'">
           <div id="event-progress-{{ event._id }}" class="ui progress">
@@ -39,8 +39,17 @@
           Error<span *ngIf="event.data.message">: {{ event.data.message }}</span>
         </span>
       </td>
-      <td width="10%">
-          <button (click)="openLogViewerModal(event)" [disabled]="!event.data.resource || !event.data.resource.jobs || !event.data.resource.jobs.length"
+      <td width="5%">
+        <button class="ui tiny circular negative basic right floated icon button"
+                [class.disabled]="!event.data.resource.jobs"
+                [disabled]="!event.data.resource.jobs"
+                *ngIf="event.data.state === 'active'"
+                (click)="cancelJob(event)">
+          <i class="times icon"></i>
+        </button>
+      </td>
+      <td width="20%">
+          <button (click)="openLogViewerModal(event)" [disabled]="!event.data.resource || !event.data.resource.jobs"
                 class="ui tiny primary basic right floated button">
             View Logs
           </button>

--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -40,16 +40,15 @@
         </span>
       </td>
       <td width="5%">
-        <button class="ui tiny circular negative basic right floated icon button"
-                [class.disabled]="!event.data.resource.jobs"
-                [disabled]="!event.data.resource.jobs"
+        <button class="ui tiny negative basic right floated icon button"
+                [disabled]="!event?.data?.resource?.jobs?.length"
                 *ngIf="event.data.state === 'active'"
                 (click)="cancelJob(event)">
           <i class="times icon"></i>
         </button>
       </td>
       <td width="20%">
-          <button (click)="openLogViewerModal(event)" [disabled]="!event.data.resource || !event.data.resource.jobs"
+          <button (click)="openLogViewerModal(event)" [disabled]="!event?.data?.resource?.jobs?.length"
                 class="ui tiny primary basic right floated button">
             View Logs
           </button>

--- a/src/app/layout/notification-stream/notification-stream.component.html
+++ b/src/app/layout/notification-stream/notification-stream.component.html
@@ -34,6 +34,10 @@
           <i class="ui fas fa-fw fa-pause yellow icon"></i>
           Queued<span *ngIf="event.data.message">: {{ event.data.message }}</span>
         </span>
+        <span  *ngSwitchCase="'canceling'">
+          <i class="ui fas fa-fw fas fa-circle-notch fa-spin brown icon"></i>
+          Canceling<span *ngIf="event.data.message">: {{ event.data.message }}</span>
+        </span>
         <span  *ngSwitchCase="'canceled'">
           <i class="ui fas fa-fw fa-stop brown icon"></i>
           Canceled<span *ngIf="event.data.message">: {{ event.data.message }}</span>


### PR DESCRIPTION
## Problem
There is no way to cancel running jobs from the WholeTale Dashboard

Fixes #307 

## Approach
* NotificationStream - add a Cancel button beside the progress bar of running jobs
    * Show this button only if the `event.data.state === 'active'`
    * Button should only be clickable if `event.data.resource.jobs.length` is truthy

<img width="685" alt="Screen Shot 2022-12-05 at 1 08 29 PM" src="https://user-images.githubusercontent.com/1413653/205722147-83c9db4c-458d-4ea5-9b97-92c0cc4ca640.png">

## How to Test
Prerequisites: at least one Tale created

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Launch a Tale
    * You should be brought to the Run Tale page
    * You should see the NotificationStream appear at the top-left with a new event
    * You should see that the new event shows that your Tale image is now building
    * You should see a red X button beside this running job - this is the Cancel button
4. Click the X beside the running Job
    * NOTE: you may need to click multiple times, as multiple jobs are sometimes triggered after one another (e.g. launch instance = build image + create volume + start container)
    * You should see that eventually the job goes into the Error state and the Cancel button is no longer clickable
5. Expand the Tale dropdown at the top-right, choose "Recorded Run", and Submit the modal dialog that appears
    * You should see the NotificationStream appear at the top-left with a new event
    * You should see that the new event shows that your Recorded Run is now executing
    * You should see a red X button beside this running job - this is the Cancel button
6. Click the X beside the running Job
    * NOTE: you may need to click multiple times, as multiple jobs are sometimes triggered after one another
    * You should see that eventually the job goes into the Error state and the Cancel button is no longer clickable