### PR TITLE
feat: add working compute environments listing

### DIFF
--- a/src/app/+compute-environments/compute-environments.component.html
+++ b/src/app/+compute-environments/compute-environments.component.html
@@ -1,0 +1,87 @@
+<div fxLayoutAlign="center" [@routeAnimation]>
+  <div class="ui stackable grid container">
+    <!-- <div class="row">
+        <div class="sixteen wide column">
+            <div class="ui secondary pointing menu">
+                <a href="browse-env.html" class="active item">
+            Public Environments
+        </a>
+                <a href="" class="item">
+            My Environments
+        </a>
+                <div class="right menu">
+                    <div class="item">
+                        <div class="ui primary right labeled icon button" id="add-env">
+                            Add Environment
+                            <i class="plus icon"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div> -->
+
+    <div class="row">
+      <div class="sixteen wide column">
+
+        <div class="ui fluid icon wt-input input" style="margin-bottom:1em">
+          <input type="text" placeholder="Search WholeTale Environments...">
+          <i class="search icon"></i>
+        </div>
+
+        <div class="ui styled fluid accordion" *ngFor="let environment of environments; index as index">
+          <span>
+            <div class="title">
+              <div class="label">
+                <img [src]="environment.icon" alt="RStudio">
+              </div>
+              <div class="listing">
+                <h3>{{ environment.name }}</h3> {{ environment.description }}
+              </div>
+              <!--<div class="ui floating dropdown theme" tabindex="0">
+                <i class="fas fa-ellipsis-v"></i>
+                <div class="menu transition hidden" tabindex="-1">
+                  <div class="item">Save to My Environments</div>
+                  <a class="item">Use in Existing Tale</a>
+                  <a class="item">Create New Tale</a>
+                </div>
+              </div>-->
+            </div>
+            <div class="content">
+            <div class="ui list transition hidden">
+              <div class="ui stackable grid">
+                <div class="ui six wide column">
+                  <div class="item">
+                    <b>Name:</b> {{ environment.name }}
+                  </div>
+                  <div class="item" *ngIf="environment.description">
+                    <b>Description:</b> {{ environment.description }}
+                  </div>
+                  <div class="item" *ngIf="environment | taleCreator | async as creator">
+                    <b>Creator:</b>
+                    <img *ngIf="creator.gravatar_baseUrl" alt="avatar" [src]="creator.gravatar_baseUrl" />
+                    {{ creator.firstName }} {{ creator.lastName }}
+                  </div>
+                  <div class="item">
+                    <b>Is Public:</b> {{ environment.public ? 'Yes' : 'No' }}
+                  </div>
+                </div>
+                <div class="ui ten wide column">
+                  <div class="item">
+                    <b>Configuration:</b>
+                    <div class="ui message">
+                      <pre>{{ environment.config | json }}</pre>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+          </span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/src/app/+compute-environments/compute-environments.component.scss
+++ b/src/app/+compute-environments/compute-environments.component.scss
@@ -1,0 +1,13 @@
+@import '~src/assets/sass/mixin/bem';
+@import '~src/assets/sass/layout/card';
+@import '~src/assets/sass/layout/page';
+
+@include page_layout;
+@include card_layout;
+
+.card_header {
+  @include el('image') {
+    background-image: url('https://avatars3.githubusercontent.com/u/19705696');
+    background-size: cover;
+  }
+}

--- a/src/app/+compute-environments/compute-environments.component.spec.ts
+++ b/src/app/+compute-environments/compute-environments.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ComputeEnvironmentsComponent } from './compute-environments.component';
+
+describe('ComputeEnvironmentsComponent', () => {
+  let component: ComputeEnvironmentsComponent;
+  let fixture: ComponentFixture<ComputeEnvironmentsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ComputeEnvironmentsComponent ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ComputeEnvironmentsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/+compute-environments/compute-environments.component.ts
+++ b/src/app/+compute-environments/compute-environments.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Image } from '@api/models/image';
+import { ImageService } from '@api/services/image.service';
+import { routeAnimation } from '@shared/animations';
+import { BaseComponent } from '@shared/core';
+
+declare var $: any;
+
+@Component({
+  templateUrl: './compute-environments.component.html',
+  styleUrls: ['./compute-environments.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [routeAnimation]
+})
+export class ComputeEnvironmentsComponent extends BaseComponent implements OnInit {
+  environments: Array<Image> = [];
+
+  constructor(private imageService: ImageService, private ref: ChangeDetectorRef) {
+    super();
+  }
+
+  ngOnInit(): void {
+    const params = { limit: 10 };
+    this.imageService.imageListImages(params).subscribe((images: Array<Image>) => {
+      this.environments = images;
+      this.ref.detectChanges();
+
+      setTimeout(() => {
+        $('.ui.accordion').accordion();
+        $('.ui.dropdown').dropdown();
+      },200);
+    })
+  }
+}

--- a/src/app/+compute-environments/compute-environments.module.ts
+++ b/src/app/+compute-environments/compute-environments.module.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { MaterialModule } from '@shared/material/material.module';
+import { SharedModule } from '@shared/shared.module';
+import { TalesModule } from '@tales/tales.module';
+
+import { ComputeEnvironmentsComponent } from './compute-environments.component';
+import { routes } from './compute-environments.routes';
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(routes), SharedModule, MaterialModule, TalesModule],
+  declarations: [ComputeEnvironmentsComponent]
+})
+export class ComputeEnvironmentsModule { }

--- a/src/app/+compute-environments/compute-environments.routes.ts
+++ b/src/app/+compute-environments/compute-environments.routes.ts
@@ -1,0 +1,17 @@
+// import { AuthGuard } from '@ngx-auth/core';
+
+import { ComputeEnvironmentsComponent } from './compute-environments.component';
+
+export const routes = [
+  {
+    path: '',
+    component: ComputeEnvironmentsComponent,
+    // canActivate: [AuthGuard],
+    data: {
+      meta: {
+        title: 'COMPUTE_ENVIRONMENTS.PAGE_TITLE',
+        description: 'COMPUTE_ENVIRONMENTS.META_DESCRIPTION'
+      }
+    }
+  }
+];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,10 @@ export const routes = [
     component: MainComponent,
     children: [
       {
+        path: 'environments',
+        loadChildren: () => import('./+compute-environments/compute-environments.module').then((m) => m.ComputeEnvironmentsModule),
+      },
+      {
         path: 'run',
         loadChildren: () => import('./+run-tale/run-tale.module').then((m) => m.RunTaleModule),
       },

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -3,7 +3,7 @@
     <a class="header item wt-brand" href="https://wholetale.org"><img src="assets/img/wholetale_logo_sm.png">Whole<span>Tale</span></a>
     <a class="item" [ngClass]="{ 'active':currentRoute==='/mine' || currentRoute==='/public' || currentRoute==='/shared' }" [routerLink]="user ? '/mine' : '/public'" routerLinkActive="active">Tale Dashboard</a>
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
-    <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
+    <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a>
     <div class="right menu">
         <a class="item" [href]="docUrl" target="_blank" matTooltip="Open user's guide">
         <i class="info circle white icon"></i>

--- a/src/app/tales/pipes/tale-creator.pipe.ts
+++ b/src/app/tales/pipes/tale-creator.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { Image } from '@api/models/image';
 import { Tale } from '@api/models/tale';
 import { UserService } from '@api/services/user.service';
 import { EMPTY, Observable } from 'rxjs';
@@ -9,7 +10,7 @@ import { EMPTY, Observable } from 'rxjs';
 export class TaleCreatorPipe implements PipeTransform {
   constructor(private readonly userService: UserService) {}
 
-  transform(value: Tale): Observable<any> {
+  transform(value: Tale | Image): Observable<any> {
     if (!value || !value.creatorId) {
       return EMPTY;
     }


### PR DESCRIPTION
## Problem
A view listing out the available **Compute Environments** was mocked up, but never implemented

## Approach
Bring this view to life by connecting it with the API.

* Read-only for now, unless we want more
    * NOTE: I have skipped the Dropdown options from the mockup, as they proved to be more complicated than I initially thought. If we want this feature, I can give it another go

<img width="1678" alt="Screen Shot 2022-12-05 at 2 54 32 PM" src="https://user-images.githubusercontent.com/1413653/205740892-92bdb011-ce84-45cf-b08b-596cf53515e4.png">

## How to Test
1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
    * You should see a new link in the navbar that links to the **Compute Environments**
3. Click the Compute Environments nav
    * You should be brought to the new `/environments` view
    * You should see a list (accordion) of all available Images that have been created in WholeTale
4. Click on an image in the list
    * You should see the accordion expand to show more information about the chosen Image
