### PR TITLE
feat: prompt for instance shutdown when Tale delete=409

### DIFF
--- a/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/my-tales/my-tales.component.html
@@ -13,7 +13,7 @@
     </div>
 
   <!-- Running Tales -->
-  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales"></app-running-tales>
+  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales" (taleDeleted)="refresh()"></app-running-tales>
 
   <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(tales | myTales | stopped:instances) as allStoppedTales">
     <div class="sixteen wide column" *ngIf="(tales | searchTales:searchQuery:creators | myTales | stopped:instances) as filteredStoppedTales">

--- a/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/public-tales/public-tales.component.html
@@ -13,7 +13,7 @@
     </div>
 
   <!-- Running Tales -->
-  <app-running-tales *ngIf="tokenService.user.value" [instances]="instances" [creators]="creators" [taleList]="tales"></app-running-tales>
+  <app-running-tales *ngIf="tokenService.user.value" [instances]="instances" [creators]="creators" [taleList]="tales" (taleDeleted)="refresh()"></app-running-tales>
 
   <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(tales | publicTales) as allPublicTales">
     <div class="sixteen wide column" *ngIf="(tales | searchTales:searchQuery:creators | publicTales) as filteredPublicTales">

--- a/src/app/+tale-catalog/tale-catalog/components/running-tales/running-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/running-tales/running-tales.component.html
@@ -18,6 +18,7 @@
         <div class="ui two stackable doubling selectable special cards">
           <div class="ui card" *ngFor="let tale of filteredRunningTales; index as i; trackBy: trackById">
             <div class="extra content">
+              <div class="right floated meta" (click)="openDeleteTaleModal(tale)"><i class="close icon"></i></div>
               <span style="text-transform:uppercase">
                 {{ tale.copyOfTale ? 'copy' : 'original' }}
               </span>

--- a/src/app/+tale-catalog/tale-catalog/components/shared-tales/shared-tales.component.html
+++ b/src/app/+tale-catalog/tale-catalog/components/shared-tales/shared-tales.component.html
@@ -13,7 +13,7 @@
     </div>
 
   <!-- Running Tales -->
-  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales"></app-running-tales>
+  <app-running-tales [instances]="instances" [creators]="creators" [taleList]="tales" (taleDeleted)="refresh()"></app-running-tales>
 
   <!-- Shared Tales -->
   <div class="row" style="margin-top:40px;margin-bottom:30px;" *ngIf="(tales | sharedTales | stopped:instances) as allStoppedTales">

--- a/src/app/api/services/tale.service.ts
+++ b/src/app/api/services/tale.service.ts
@@ -204,6 +204,7 @@ class TaleService extends __BaseService {
     let __body: any = null;
 
     if (params.progress != null) __params = __params.set('progress', params.progress.toString());
+    if (params.force != null) __params = __params.set('force', params.force.toString());
     let req = new HttpRequest<any>('DELETE', this.rootUrl + `/tale/${params.id}`, __body, {
       headers: __headers,
       params: __params,
@@ -729,6 +730,11 @@ module TaleService {
      * Whether to record progress on this task.
      */
     progress?: boolean;
+
+    /**
+     * Whether to force deletion when Instances of this Tale still exist.
+     */
+    force?: boolean;
   }
 
   /**


### PR DESCRIPTION
## Problem
We now have the option to force deletion of Tale instances from the UI, but UI needs to handle the new `force` API parameter

Fixes #229 

## Approach
* Ask user for confirmation - if yes, shutdown running Instance(s) and delete the Tale 

NOTE: there are two paths for this - the "Running Tales" section has its own handling that is separate from the rest of the page

<img width="376" alt="Screen Shot 2022-12-19 at 1 29 45 PM" src="https://user-images.githubusercontent.com/1413653/208504793-a29e491a-c804-4335-8ad8-568e504fca97.png">

## How to Test
Prerequisites: at least one Tale running that you own

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard
3. Navigate to the Tale Catalog and find a Tale that you own
4. Start the Tale, if you haven't already
    * You should be navigated to the Run Tale page
6. Go back to the Tale Dashboard and click the X on the Tale to delete it
    * You should see the Delete Tale modal appear
7. Confirm this modal and you should see a `ConfirmationModal` appear
    * You should see this modal warns you about running instances and the consequences for deleting them
8.  After confirming, you should see the Tale and Instances are now deleted