### PR TITLE
Enable basic branding

### DIFF
--- a/src/app/api/services/wholetale.service.ts
+++ b/src/app/api/services/wholetale.service.ts
@@ -13,6 +13,7 @@ import { map as __map, filter as __filter } from 'rxjs/operators';
 class WholetaleService extends __BaseService {
   static readonly wholetaleGetWholetaleInfoPath = '/wholetale';
   static readonly wholetaleRegenerateCitationsPath = '/wholetale/citations';
+  static readonly wholetaleGetWholetaleSettingsPath = '/wholetale/settings';
 
   constructor(config: __Configuration, http: HttpClient) {
     super(config, http);
@@ -63,6 +64,28 @@ class WholetaleService extends __BaseService {
    */
   wholetaleRegenerateCitations(): __Observable<null> {
     return this.wholetaleRegenerateCitationsResponse().pipe(__map(_r => _r.body as null));
+  }
+
+  wholetaleGetSettingsResponse(): __Observable<__StrictHttpResponse<null>> {
+    let __params = this.newParams();
+    let __headers = new HttpHeaders();
+    let __body: any = null;
+    let req = new HttpRequest<any>('GET', this.rootUrl + `/wholetale/settings`, __body, {
+      headers: __headers,
+      params: __params,
+      responseType: 'json'
+    });
+
+    return this.http.request<any>(req).pipe(
+      __filter(_r => _r instanceof HttpResponse),
+      __map(_r => {
+        return _r as __StrictHttpResponse<null>;
+      })
+    );
+  }
+
+  wholetaleGetSettings(): __Observable<null> {
+    return this.wholetaleGetSettingsResponse().pipe(__map(_r => _r.body as null));
   }
 }
 

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -1,7 +1,11 @@
 
-<div class="ui inverted menu wt-top">
-    <a class="header item wt-brand" href="https://wholetale.org"><img src="assets/img/wholetale_logo_sm.png">Whole<span>Tale</span></a>
+<div class="ui inverted menu wt-top" [ngStyle]="{'background': settings['core.banner_color'] }" *ngIf="settings">
+	<a class="header item wt-brand" [href]="settings['wholetale.website_url']">
+		<img [src]="logoUrl" *ngIf="logoUrl">
+		{{ settings["core.brand_name"] }}
+	</a>
     <a class="item" [ngClass]="{ 'active':currentRoute==='/mine' || currentRoute==='/public' || currentRoute==='/shared' }" [routerLink]="user ? '/mine' : '/public'" routerLinkActive="active">Tale Dashboard</a>
+    <a class="item" href="https://girder.local.wholetale.org/" *ngIf="settings['wholetale.enable_data_catalog']">{{ settings["wholetale.catalog_link_title"] }}</a>
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">

--- a/src/app/layout/header.component.scss
+++ b/src/app/layout/header.component.scss
@@ -14,7 +14,6 @@
 }
 
 .ui.inverted.menu.wt-top {
-  background: #132f43;
   font-size: 1.1rem;
   -moz-border-radius: 0;
   -webkit-border-radius: 0;


### PR DESCRIPTION
## Problem
Branding items such as the dashboard instance name, header color, and logo are hardcoded. With https://github.com/whole-tale/girder_wholetale/pull/572, this PR adds branding configuration support via a new `/wholetale/settings` endpoint.

## How to Test
- See https://github.com/whole-tale/girder_wholetale/pull/572 for test case