### PR TITLE
fix: don't hardcode data catalog url

### DIFF
--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -5,7 +5,7 @@
 		{{ settings["core.brand_name"] }}
 	</a>
     <a class="item" [ngClass]="{ 'active':currentRoute==='/mine' || currentRoute==='/public' || currentRoute==='/shared' }" [routerLink]="user ? '/mine' : '/public'" routerLinkActive="active">Tale Dashboard</a>
-    <a class="item" href="https://girder.local.wholetale.org/" *ngIf="settings['wholetale.enable_data_catalog']">{{ settings["wholetale.catalog_link_title"] }}</a>
+    <a class="item" [href]="dataUrl" *ngIf="settings['wholetale.enable_data_catalog']">{{ settings["wholetale.catalog_link_title"] }}</a>
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/datasets' }" routerLink="/datasets" routerLinkActive="active">Data Catalog</a> -->
     <!-- <a class="item" [ngClass]="{ 'active':currentRoute==='/environments' }" routerLink="/environments" routerLinkActive="active">Compute Environments</a> -->
     <div class="right menu">


### PR DESCRIPTION
## Problem

Data catalog link is hardcoded

## Approach

Use `rootUrl` to derive a proper link

>  **Note**
> Other seemingly unrelated changes were made to make linter happy...

## How to Test

Prerequisites: <!-- e.g. Tale created/launched, at least one file/folder, etc -->

1. Checkout this branch locally, rebuild the dashboard
2. Enable Data Catalog
3. Go to dashboard and check Data Catalog links to girder.
