### PR TITLE
fix: respect AUTH_PROVIDER and cookies coming from .girder

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ng-bullet": "~1.0.3",
     "ng-event-source": "1.0.14",
     "ng-swagger-gen": "2.3.1",
-    "ngx-cookie-service": "2.2.0",
+    "ngx-cookie-service": "~12.0.3",
     "ngx-markdown": "^12.0.0",
     "nightmare": "~3.0.1",
     "prettier": "~2.3.2",

--- a/src/app/+about/about.component.ts
+++ b/src/app/+about/about.component.ts
@@ -49,6 +49,12 @@ export class AboutComponent extends BaseComponent implements OnInit {
 
     this.isAuthenticated = false; // this.auth.isAuthenticated;
 
+    const girderToken = this.cookies.get('girderToken');
+    if (girderToken) {
+      this.tokenService.setToken(girderToken);
+      // this.login();
+    }
+
     // Try to scrape token from query string param
     const token = this.route.snapshot.queryParams.token;
     if (token) {

--- a/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
+++ b/src/app/+run-tale/run-tale/tale-files/tale-files.component.ts
@@ -714,9 +714,9 @@ export class TaleFilesComponent implements OnInit, OnChanges, OnDestroy {
                       .pipe(enterZone(this.zone))
                       .subscribe(
       newFolder => {
-        //const folders = this.folders.value;
-        //folders.push(newFolder);
-        //this.folders.next(folders);
+        // const folders = this.folders.value;
+        // folders.push(newFolder);
+        // this.folders.next(folders);
 
         this.load();
       },

--- a/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
+++ b/src/app/+tale-catalog/tale-catalog/tale-catalog.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, ChangeDetectorRef, Component, EventEmitter, NgZone, OnDestroy, OnInit, Output } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ApiConfiguration } from '@api/api-configuration';
 import { Tale } from '@api/models/tale';
 import { User } from '@api/models/user';
 import { OauthService } from '@api/services/oauth.service';
@@ -37,6 +38,7 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
       private route: ActivatedRoute,
       private ref: ChangeDetectorRef,
       private oauth: OauthService,
+      private readonly config: ApiConfiguration,
       public tokenService: TokenService,
       public dialog: MatDialog
     ) {
@@ -73,9 +75,9 @@ export class TaleCatalogComponent extends BaseComponent implements AfterViewInit
 
             // FIXME: is it ok to use window.location.origin here?
             const params = { redirect: `${window.location.origin}/?token={girderToken}&rd=${redirect}`, list: false };
-            this.oauth.oauthListProviders(params).subscribe((providers: { Globus: string, Github: string }) => {
+            this.oauth.oauthListProviders(params).subscribe((providers: Map<String, String>) => {
                 // TODO: How to support multiple providers here?
-                window.location.href = providers.Globus;
+                window.location.href = providers[this.config.authProvider];
               },
               (err) => {
                 this.logger.error('Failed to GET /oauth/providers:', err);

--- a/src/app/api/api-configuration.ts
+++ b/src/app/api/api-configuration.ts
@@ -9,12 +9,15 @@ import { Injectable } from '@angular/core';
 })
 export class ApiConfiguration {
   rootUrl: string;
+  authProvider: string;
 
   constructor() {
     this.rootUrl = window.env.apiUrl;
+    this.authProvider = window.env.authProvider;
   }
 }
 
 export interface ApiConfigurationInterface {
   rootUrl?: string;
+  authProvider?: string;
 }

--- a/src/app/api/api.module.ts
+++ b/src/app/api/api.module.ts
@@ -94,7 +94,7 @@ export class ApiModule {
       providers: [
         {
           provide: ApiConfiguration,
-          useValue: { rootUrl: customParams.rootUrl },
+          useValue: { rootUrl: customParams.rootUrl, authProvider: customParams.authProvider },
         },
       ],
     };

--- a/src/app/api/auth-guard.ts
+++ b/src/app/api/auth-guard.ts
@@ -10,11 +10,13 @@ import {
   UrlSegment,
   UrlTree,
 } from '@angular/router';
+import { ApiConfiguration } from '@api/api-configuration';
 import { User } from '@api/models/user';
 import { OauthService } from '@api/services/oauth.service';
 import { UserService } from '@api/services/user.service';
 import { TokenService } from '@api/token.service';
 import { LogService } from '@shared/core';
+import { CookieService } from 'ngx-cookie-service';
 import { Observable } from 'rxjs';
 
 @Injectable()
@@ -24,7 +26,9 @@ export class AuthGuard implements CanActivateChild, CanActivate, CanLoad {
     private readonly tokenService: TokenService,
     private readonly userService: UserService,
     private readonly oauth: OauthService,
-    private readonly logger: LogService
+    private readonly cookies: CookieService,
+    private readonly logger: LogService,
+    private readonly config: ApiConfiguration
   ) {}
 
   get token(): string {
@@ -37,6 +41,10 @@ export class AuthGuard implements CanActivateChild, CanActivate, CanLoad {
 
   // Returns true if the user is logged in
   checkAuth(): boolean {
+    const girderToken = this.cookies.get('girderToken');
+    if (girderToken) {
+      this.tokenService.setToken(girderToken);
+    }
     if (this.token && this.user) {
       // Shortcut for token and user already fetched
       return true;
@@ -59,9 +67,9 @@ export class AuthGuard implements CanActivateChild, CanActivate, CanLoad {
     // FIXME: is it ok to use window.location.origin here?
     const params = { redirect: `${window.location.origin}/?token={girderToken}&rd=${redirect}`, list: false };
     this.oauth.oauthListProviders(params).subscribe(
-      (providers: { Globus: string; Github: string }) => {
+      (providers: Map<string, string>) => {
         // TODO: How to support multiple providers here?
-        window.location.href = providers.Globus;
+        window.location.href = providers[this.config.authProvider];
       },
       (err) => {
         this.logger.error('Failed to GET /oauth/providers:', err);

--- a/src/app/api/token.interceptor.ts
+++ b/src/app/api/token.interceptor.ts
@@ -27,9 +27,9 @@ export class TokenInterceptor implements HttpInterceptor {
 
     const params = { redirect: `${window.location.origin}/?token={girderToken}&rd=${redirect}`, list: false };
     this.oauth.oauthListProviders(params).subscribe(
-      (providers: { Globus: string; Github: string }) => {
+      (providers: Map<string, string>) => {
         // TODO: How to support multiple providers here?
-        window.location.href = providers.Globus;
+        window.location.href = providers[this.config.authProvider];
       },
       (err) => {
         this.logger.error('Failed to GET /oauth/providers:', err);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -52,7 +52,7 @@ declare global {
     MaterialModule,
     FontAwesomeModule,
     NotificationStreamModule,
-    ApiModule.forRoot({ rootUrl: window.env.apiUrl }),
+    ApiModule.forRoot({ rootUrl: window.env.apiUrl, authProvider: window.env.authProvider }),
   ],
   declarations: [HeaderComponent, FooterComponent, MainComponent, AppComponent],
   providers: [

--- a/src/app/layout/header.component.html
+++ b/src/app/layout/header.component.html
@@ -25,7 +25,7 @@
         </div>
       </a>
 
-      <a *ngIf="!user" class="item" (click)="loginWith('Globus')" matTooltip="Sign In">
+      <a *ngIf="!user" class="item" (click)="loginWith()" matTooltip="Sign In">
         <i class="user white icon"></i> Sign In
       </a>
       <!--<a *ngIf="!user" class="item" (click)="loginWith('Github')" matTooltip="Sign In with Github">

--- a/yarn.lock
+++ b/yarn.lock
@@ -9447,10 +9447,12 @@ ng-swagger-gen@2.3.1:
     mustache "^2.3.2"
     npm-conf "^1.1.3"
 
-ngx-cookie-service@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ngx-cookie-service/-/ngx-cookie-service-2.2.0.tgz#79fe67863b3b93ee226c9ea8d60e1542c7115a58"
-  integrity sha512-2kaC1itlEMxiMAPJ320hOpcwU9vhvjbKQCZ1Go6bGhYjJtqG7eYvhNP7mM9IhFz1/afG2tBryJPySWmFUGhRpA==
+ngx-cookie-service@~12.0.3:
+  version "12.0.3"
+  resolved "https://registry.yarnpkg.com/ngx-cookie-service/-/ngx-cookie-service-12.0.3.tgz#eb2fc73b40dcc5ef8282eb78e82986afc299537f"
+  integrity sha512-F5xJBTrrreI2DERGOrO6U+L7s031HxTER+3Z4gDCwxdTl4AXmtWddMxxQVw7KflOLZ4InYEs6FjQsXmKU4HsJg==
+  dependencies:
+    tslib "^2.0.0"
 
 ngx-markdown@^12.0.0:
   version "12.0.1"


### PR DESCRIPTION
## Problem

Dashboard doesn't respect AUTH_PROVIDER that's set on its container.

## Approach

Actually use AUTH_PROVIDER for choosing OAuth provider

## How to Test

Prerequisites: Set up Girder with any OAuth provider except for Globus. Set AUTH_PROVIDER accordingly

1. Checkout this branch locally, rebuild the dashboard
2. Login to the WholeTale Dashboard (should succeed and use chosen provider).
